### PR TITLE
WIP: op-proposer using ZKL2OutputOracle

### DIFF
--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -72,6 +72,9 @@ type TxManager interface {
 	// BlockNumber returns the most recent block number from the underlying network.
 	BlockNumber(ctx context.Context) (uint64, error)
 
+	// BlockHeader returns the most recent block header from the underlying network.
+	BlockHeader(ctx context.Context) (*types.Header, error)
+
 	// Close the underlying connection
 	Close()
 	IsClosed() bool
@@ -159,6 +162,14 @@ func (m *SimpleTxManager) From() common.Address {
 
 func (m *SimpleTxManager) BlockNumber(ctx context.Context) (uint64, error) {
 	return m.backend.BlockNumber(ctx)
+}
+
+func (m *SimpleTxManager) BlockHeader(ctx context.Context) (*types.Header, error) {
+	blockNumber, err := m.backend.BlockNumber(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return m.backend.HeaderByNumber(ctx, new(big.Int).SetUint64(blockNumber))
 }
 
 // Close closes the underlying connection, and sets the closed flag.


### PR DESCRIPTION
This PR includes the changes to `op-program` needed for it to generate a proof and interact with the ZKL2OutputOracle. This is sufficient to submit ZK proofs instead of permissioned outputs.

Remaining todos:
- [x] Add the functions to grab the blockhash to checkpoint and submit on chain
- [ ] Generate the new ABI and bindings for the ZKL2OO. Should be able to use `make op-bindings` to generate once we have contracts finalized.
- [ ] Move `kona-sp1` into the monorepo
- [ ] Plug in the correct command to generate the SP1 proof