### PR TITLE
Update pr-guidelines.md

### DIFF
--- a/docs/handbook/pr-guidelines.md
+++ b/docs/handbook/pr-guidelines.md
@@ -46,4 +46,4 @@ This is organized by current state of PR, so it can be easily referenced frequen
 ### Merging PRs
 
 - **Resolve all Comments**: Comments can be resolved by (1) the PR author for nits/optionals, (2) the author or reviewer after discussions, or (3) extracting the comment into an issue to address in a future PR. For (3), ensure the new issue links to the specific comment thread. This is currently enforced by GitHub's merge requirements.
-- **Other Standard Merge Requirements**: The PR must be approved by the appropriate reviewers, CI must passing, and other standard merge requirements apply.
+- **Other Standard Merge Requirements**: The PR must be approved by the appropriate reviewers, CI must be passing, and other standard merge requirements apply.


### PR DESCRIPTION
<img width="880" alt="Снимок экрана 2024-10-27 в 14 12 32" src="https://github.com/user-attachments/assets/42887a4d-a0f5-4a20-a526-dbfb365a13eb">

"CI must passing" → This should be corrected to "**CI must be passing**."