### PR TITLE
feat: deploy SP1 verifier at genesis + enable real proving (plonk/groth16)

### DIFF
--- a/op-chain-ops/addresses/contracts.go
+++ b/op-chain-ops/addresses/contracts.go
@@ -99,6 +99,7 @@ type OpChainLegacyContracts struct {
 }
 
 type OpSuccinctContracts struct {
+	SP1Verifier              common.Address
 	SP1MockVerifier          common.Address
 	OPSuccinctL2OutputOracle common.Address
 }

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -1225,6 +1225,7 @@ type L1Deployments struct {
 	ProtocolVersionsProxy             common.Address `json:"ProtocolVersionsProxy"`
 	DataAvailabilityChallenge         common.Address `json:"DataAvailabilityChallenge"`
 	DataAvailabilityChallengeProxy    common.Address `json:"DataAvailabilityChallengeProxy"`
+	SP1Verifier                       common.Address `json:"SP1Verifier"`
 	SP1MockVerifier                   common.Address `json:"SP1MockVerifier"`
 	OPSuccinctL2OutputOracle          common.Address `json:"OPSuccinctL2OutputOracle"`
 }
@@ -1255,6 +1256,7 @@ func CreateL1DeploymentsFromContracts(contracts *addresses.L1Contracts) *L1Deplo
 		ProtocolVersionsProxy:             contracts.ProtocolVersionsProxy,
 		DataAvailabilityChallenge:         contracts.AltDAChallengeImpl,
 		DataAvailabilityChallengeProxy:    contracts.AltDAChallengeProxy,
+		SP1Verifier:                       contracts.SP1Verifier,
 		SP1MockVerifier:                   contracts.SP1MockVerifier,
 		OPSuccinctL2OutputOracle:          contracts.OPSuccinctL2OutputOracle,
 	}

--- a/op-chain-ops/interopgen/deployments.go
+++ b/op-chain-ops/interopgen/deployments.go
@@ -91,14 +91,14 @@ func NewL2OPChainDeploymentFromDeployOPChainOutput(output opcm.DeployOPChainOutp
 }
 
 type L2OpSuccinctDeployment struct {
-	SP1MockVerifier          common.Address `json:"SP1MockVerifier"`
-	OPSuccinctL2OutputOracle common.Address `json:"OPSuccinctL2OutputOracle"`
+	SP1Verifier     common.Address `json:"SP1Verifier"`
+	SP1MockVerifier common.Address `json:"SP1MockVerifier"`
 }
 
 func NewL2OPSuccinctDeploymentFromDeployOPSuccinctOutput(output opcm.DeployOPSuccinctOutput) L2OpSuccinctDeployment {
 	return L2OpSuccinctDeployment{
-		SP1MockVerifier:          output.SP1MockVerifier,
-		OPSuccinctL2OutputOracle: output.OPSuccinctL2OutputOracle,
+		SP1Verifier:     output.SP1Verifier,
+		SP1MockVerifier: output.SP1MockVerifier,
 	}
 }
 

--- a/op-deployer/pkg/deployer/apply.go
+++ b/op-deployer/pkg/deployer/apply.go
@@ -346,6 +346,11 @@ func ApplyPipeline(
 				return pipeline.DeployAdditionalDisputeGames(pEnv, intent, st, chainID)
 			},
 		}, pipelineStage{
+			fmt.Sprintf("deploy-op-succinct-%s", chainID.Hex()),
+			func() error {
+				return pipeline.DeployOPSuccinct(pEnv, intent, st, chainID)
+			},
+		}, pipelineStage{
 			fmt.Sprintf("generate-l2-genesis-%s", chainID.Hex()),
 			func() error {
 				return pipeline.GenerateL2Genesis(pEnv, intent, bundle, st, chainID)

--- a/op-deployer/pkg/deployer/opcm/opsuccinct.go
+++ b/op-deployer/pkg/deployer/opcm/opsuccinct.go
@@ -1,13 +1,34 @@
 package opcm
 
 import (
+	"os"
+	"strings"
+
 	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
 	"github.com/ethereum/go-ethereum/common"
 )
 
+// SP1ProverMode represents the SP1 prover backend type.
+type SP1ProverMode string
+
+const (
+	SP1ProverModePlonk   SP1ProverMode = "plonk"
+	SP1ProverModeGroth16 SP1ProverMode = "groth16"
+)
+
+// GetSP1ProverMode returns the configured SP1 prover mode from environment.
+// Defaults to Plonk if not set or invalid.
+func GetSP1ProverMode() SP1ProverMode {
+	mode := strings.ToLower(os.Getenv("SP1_PROVER_MODE"))
+	if mode == "groth16" {
+		return SP1ProverModeGroth16
+	}
+	return SP1ProverModePlonk
+}
+
 type DeployOPSuccinctOutput struct {
-	SP1MockVerifier          common.Address
-	OPSuccinctL2OutputOracle common.Address
+	SP1Verifier     common.Address
+	SP1MockVerifier common.Address
 }
 
 type DeploySP1MockVerifierScript script.DeployScriptWithoutInput[common.Address]
@@ -16,29 +37,51 @@ func NewDeploySP1MockVerifierScript(host *script.Host) (DeploySP1MockVerifierScr
 	return script.NewDeployScriptWithoutInputFromFile[common.Address](host, "DeployMockVerifier.s.sol", "DeployMockVerifier")
 }
 
-type OPSuccinctDeployerScript script.DeployScriptWithoutInput[common.Address]
+type DeploySP1VerifierScript script.DeployScriptWithoutInput[common.Address]
 
-func NewOPSuccinctDeployerScript(host *script.Host) (OPSuccinctDeployerScript, error) {
-	return script.NewDeployScriptWithoutInputFromFile[common.Address](host, "OPSuccinctDeployer.s.sol", "OPSuccinctDeployer")
+// NewDeploySP1VerifierPlonkScript loads the SP1Verifier Plonk deployment script (v5.0.0).
+func NewDeploySP1VerifierPlonkScript(host *script.Host) (DeploySP1VerifierScript, error) {
+	return script.NewDeployScriptWithoutInputFromFile[common.Address](host, "DeployVerifier.s.sol", "DeployVerifierPlonk")
 }
 
+// NewDeploySP1VerifierGroth16Script loads the SP1Verifier Groth16 deployment script (v5.0.0).
+func NewDeploySP1VerifierGroth16Script(host *script.Host) (DeploySP1VerifierScript, error) {
+	return script.NewDeployScriptWithoutInputFromFile[common.Address](host, "DeployVerifier.s.sol", "DeployVerifierGroth16")
+}
+
+// NewDeploySP1VerifierScript loads the appropriate SP1Verifier deployment script based on SP1_PROVER_MODE.
+// Use this for network proving; use NewDeploySP1MockVerifierScript for local testing.
+func NewDeploySP1VerifierScript(host *script.Host) (DeploySP1VerifierScript, error) {
+	if GetSP1ProverMode() == SP1ProverModeGroth16 {
+		return NewDeploySP1VerifierGroth16Script(host)
+	}
+	return NewDeploySP1VerifierPlonkScript(host)
+}
+
+// NewDeployOPSuccinctScripts deploys OP Succinct contracts at genesis.
 func NewDeployOPSuccinctScripts(host *script.Host) DeployOPSuccinctOutput {
+	deploySP1Verifier, err := NewDeploySP1VerifierScript(host)
+	if err != nil {
+		panic("failed to load DeploySP1Verifier script: " + err.Error())
+	}
+
+	sp1VerifierAddr, err := deploySP1Verifier.Run()
+	if err != nil {
+		panic("failed to deploy SP1Verifier: " + err.Error())
+	}
+
 	deploySP1MockVerifier, err := NewDeploySP1MockVerifierScript(host)
 	if err != nil {
 		panic("failed to load DeploySP1MockVerifier script: " + err.Error())
 	}
 
 	sp1MockVerifierAddr, err := deploySP1MockVerifier.Run()
-
-	opSuccinctDeployer, err := NewOPSuccinctDeployerScript(host)
 	if err != nil {
-		panic("failed to load OPSuccinctDeployer script: " + err.Error())
+		panic("failed to deploy SP1MockVerifier: " + err.Error())
 	}
 
-	opSuccinctL2OutputOracleAddr, err := opSuccinctDeployer.Run()
-
 	return DeployOPSuccinctOutput{
-		SP1MockVerifier:          sp1MockVerifierAddr,
-		OPSuccinctL2OutputOracle: opSuccinctL2OutputOracleAddr,
+		SP1Verifier:     sp1VerifierAddr,
+		SP1MockVerifier: sp1MockVerifierAddr,
 	}
 }

--- a/op-deployer/pkg/deployer/opcm/opsuccinct.go
+++ b/op-deployer/pkg/deployer/opcm/opsuccinct.go
@@ -1,29 +1,33 @@
 package opcm
 
 import (
-	"os"
 	"strings"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// SP1ProverMode represents the SP1 prover backend type.
-type SP1ProverMode string
+// SP1ProofMode represents the SP1 prover backend type.
+type SP1ProofMode string
 
 const (
-	SP1ProverModePlonk   SP1ProverMode = "plonk"
-	SP1ProverModeGroth16 SP1ProverMode = "groth16"
+	SP1ProofModePlonk   SP1ProofMode = "plonk"
+	SP1ProofModeGroth16 SP1ProofMode = "groth16"
 )
 
-// GetSP1ProverMode returns the configured SP1 prover mode from environment.
-// Defaults to Plonk if not set or invalid.
-func GetSP1ProverMode() SP1ProverMode {
-	mode := strings.ToLower(os.Getenv("SP1_PROVER_MODE"))
-	if mode == "groth16" {
-		return SP1ProverModeGroth16
+// SP1ProofModeOverrideKey is the global deploy override key used to select the SP1 proof mode.
+// This is consumed by the op-deployer OP Succinct pipeline stage.
+const SP1ProofModeOverrideKey = "sp1ProofMode"
+
+// ParseSP1ProofMode parses a user-provided proof mode string.
+// Defaults to Plonk if unset or unrecognized.
+func ParseSP1ProofMode(mode string) SP1ProofMode {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case string(SP1ProofModeGroth16):
+		return SP1ProofModeGroth16
+	default:
+		return SP1ProofModePlonk
 	}
-	return SP1ProverModePlonk
 }
 
 type DeployOPSuccinctOutput struct {
@@ -49,18 +53,18 @@ func NewDeploySP1VerifierGroth16Script(host *script.Host) (DeploySP1VerifierScri
 	return script.NewDeployScriptWithoutInputFromFile[common.Address](host, "DeployVerifier.s.sol", "DeployVerifierGroth16")
 }
 
-// NewDeploySP1VerifierScript loads the appropriate SP1Verifier deployment script based on SP1_PROVER_MODE.
+// NewDeploySP1VerifierScript loads the appropriate SP1Verifier deployment script based on mode.
 // Use this for network proving; use NewDeploySP1MockVerifierScript for local testing.
-func NewDeploySP1VerifierScript(host *script.Host) (DeploySP1VerifierScript, error) {
-	if GetSP1ProverMode() == SP1ProverModeGroth16 {
+func NewDeploySP1VerifierScript(host *script.Host, mode SP1ProofMode) (DeploySP1VerifierScript, error) {
+	if mode == SP1ProofModeGroth16 {
 		return NewDeploySP1VerifierGroth16Script(host)
 	}
 	return NewDeploySP1VerifierPlonkScript(host)
 }
 
 // NewDeployOPSuccinctScripts deploys OP Succinct contracts at genesis.
-func NewDeployOPSuccinctScripts(host *script.Host) DeployOPSuccinctOutput {
-	deploySP1Verifier, err := NewDeploySP1VerifierScript(host)
+func NewDeployOPSuccinctScripts(host *script.Host, mode SP1ProofMode) DeployOPSuccinctOutput {
+	deploySP1Verifier, err := NewDeploySP1VerifierScript(host, mode)
 	if err != nil {
 		panic("failed to load DeploySP1Verifier script: " + err.Error())
 	}

--- a/op-deployer/pkg/deployer/pipeline/opsuccinct.go
+++ b/op-deployer/pkg/deployer/pipeline/opsuccinct.go
@@ -12,7 +12,11 @@ func DeployOPSuccinct(env *Env, intent *state.Intent, st *state.State, chainID c
 	lgr := env.Logger.New("stage", "deploy-opsuccinct", "chain", chainID.Hex())
 	lgr.Info("Deploying OP Succinct contracts")
 
-	output := opcm.NewDeployOPSuccinctScripts(env.L1ScriptHost)
+	mode, err := sp1ProofModeFromIntent(intent)
+	if err != nil {
+		return err
+	}
+	output := opcm.NewDeployOPSuccinctScripts(env.L1ScriptHost, mode)
 
 	chainState, err := st.Chain(chainID)
 	if err != nil {
@@ -23,4 +27,19 @@ func DeployOPSuccinct(env *Env, intent *state.Intent, st *state.State, chainID c
 	chainState.SP1MockVerifier = output.SP1MockVerifier
 
 	return nil
+}
+
+func sp1ProofModeFromIntent(intent *state.Intent) (opcm.SP1ProofMode, error) {
+	if intent == nil || len(intent.GlobalDeployOverrides) == 0 {
+		return opcm.SP1ProofModePlonk, nil
+	}
+	raw, ok := intent.GlobalDeployOverrides[opcm.SP1ProofModeOverrideKey]
+	if !ok || raw == nil {
+		return opcm.SP1ProofModePlonk, nil
+	}
+	modeStr, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("%s must be a string (got %T)", opcm.SP1ProofModeOverrideKey, raw)
+	}
+	return opcm.ParseSP1ProofMode(modeStr), nil
 }

--- a/op-deployer/pkg/deployer/pipeline/opsuccinct.go
+++ b/op-deployer/pkg/deployer/pipeline/opsuccinct.go
@@ -1,0 +1,26 @@
+package pipeline
+
+import (
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func DeployOPSuccinct(env *Env, intent *state.Intent, st *state.State, chainID common.Hash) error {
+	lgr := env.Logger.New("stage", "deploy-opsuccinct", "chain", chainID.Hex())
+	lgr.Info("Deploying OP Succinct contracts")
+
+	output := opcm.NewDeployOPSuccinctScripts(env.L1ScriptHost)
+
+	chainState, err := st.Chain(chainID)
+	if err != nil {
+		return fmt.Errorf("failed to get chain state: %w", err)
+	}
+
+	chainState.SP1Verifier = output.SP1Verifier
+	chainState.SP1MockVerifier = output.SP1MockVerifier
+
+	return nil
+}

--- a/op-devstack/stack/l2_network.go
+++ b/op-devstack/stack/l2_network.go
@@ -64,6 +64,7 @@ type L2Deployment interface {
 	SystemConfigProxyAddr() common.Address
 	DisputeGameFactoryProxyAddr() common.Address
 	L1StandardBridgeProxyAddr() common.Address
+	SP1VerifierAddr() common.Address
 	SP1MockVerifierAddr() common.Address
 	OPSuccinctL2OutputOracleAddr() common.Address
 	// Other addresses will be added here later

--- a/op-devstack/sysext/addrbook.go
+++ b/op-devstack/sysext/addrbook.go
@@ -16,7 +16,8 @@ const (
 	DisputeGameFactoryName    = "disputeGameFactoryProxy"
 	L1StandardBridgeProxyName = "l1StandardBridgeProxy"
 
-	SP1MockVerifier          = "sp1MockVerifier"
+	SP1Verifier              = "sp1Verifier"
+	sp1MockVerifier          = "sp1MockVerifier"
 	OPSuccinctL2OutputOracle = "opSuccinctL2OutputOracle"
 )
 
@@ -44,6 +45,7 @@ type l2AddressBook struct {
 	systemConfig             common.Address
 	disputeGameFactory       common.Address
 	l1StandardBridge         common.Address
+	sp1Verifier              common.Address
 	sp1MockVerifier          common.Address
 	opSuccinctL2OutputOracle common.Address
 }
@@ -53,7 +55,8 @@ func newL2AddressBook(l1Addresses descriptors.AddressMap) *l2AddressBook {
 		systemConfig:             l1Addresses[SystemConfigAddressName],
 		disputeGameFactory:       l1Addresses[DisputeGameFactoryName],
 		l1StandardBridge:         l1Addresses[L1StandardBridgeProxyName],
-		sp1MockVerifier:          l1Addresses[SP1MockVerifier],
+		sp1Verifier:              l1Addresses[SP1Verifier],
+		sp1MockVerifier:          l1Addresses[sp1MockVerifier],
 		opSuccinctL2OutputOracle: l1Addresses[OPSuccinctL2OutputOracle],
 	}
 }
@@ -68,6 +71,10 @@ func (a *l2AddressBook) DisputeGameFactoryProxyAddr() common.Address {
 
 func (a *l2AddressBook) L1StandardBridgeProxyAddr() common.Address {
 	return a.l1StandardBridge
+}
+
+func (a *l2AddressBook) SP1VerifierAddr() common.Address {
+	return a.sp1Verifier
 }
 
 func (a *l2AddressBook) SP1MockVerifierAddr() common.Address {

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/inspect"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
@@ -53,6 +54,14 @@ func WithForkAtL1Genesis(fork forks.Fork) DeployerOption {
 func WithForkAtL1Offset(fork forks.Fork, offset uint64) DeployerOption {
 	return func(_ devtest.P, _ devkeys.Keys, builder intentbuilder.Builder) {
 		builder.L1().WithL1ForkAtOffset(fork, &offset)
+	}
+}
+
+// WithSP1ProofMode configures the SP1 verifier backend used for OP Succinct deployment.
+// Supported values: "plonk" (default) and "groth16".
+func WithSP1ProofMode(mode string) DeployerOption {
+	return func(_ devtest.P, _ devkeys.Keys, builder intentbuilder.Builder) {
+		builder.WithGlobalOverride(opcm.SP1ProofModeOverrideKey, string(opcm.ParseSP1ProofMode(mode)))
 	}
 }
 

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -1,6 +1,7 @@
 package sysgo
 
 import (
+	"fmt"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -174,6 +175,7 @@ type L2Deployment struct {
 	l1StandardBridgeProxy          common.Address
 	proxyAdmin                     common.Address
 	permissionlessDelayedWETHProxy common.Address
+	sp1Verifier                    common.Address
 	sp1MockVerifier                common.Address
 	opSuccinctL2OutputOracle       common.Address
 }
@@ -200,12 +202,32 @@ func (d *L2Deployment) PermissionlessDelayedWETHProxyAddr() common.Address {
 	return d.permissionlessDelayedWETHProxy
 }
 
+func (d *L2Deployment) SP1VerifierAddr() common.Address {
+	return d.sp1Verifier
+}
+
 func (d *L2Deployment) SP1MockVerifierAddr() common.Address {
 	return d.sp1MockVerifier
 }
 
 func (d *L2Deployment) OPSuccinctL2OutputOracleAddr() common.Address {
 	return d.opSuccinctL2OutputOracle
+}
+
+// resolveSP1VerifierAddr returns the appropriate SP1 verifier address based on proving mode.
+// Uses the real verifier for network proving (when NETWORK_PRIVATE_KEY is set),
+// otherwise uses the mock verifier for local testing.
+func (d *L2Deployment) resolveSP1VerifierAddr() (common.Address, error) {
+	var addr common.Address
+	if os.Getenv("NETWORK_PRIVATE_KEY") != "" {
+		addr = d.sp1Verifier
+	} else {
+		addr = d.sp1MockVerifier
+	}
+	if addr == (common.Address{}) {
+		return common.Address{}, fmt.Errorf("verifier address is zero; ensure SP1 verifier is deployed")
+	}
+	return addr, nil
 }
 
 type InteropMigration struct {
@@ -452,6 +474,7 @@ func (wb *worldBuilder) buildL2DeploymentOutputs() {
 			l1StandardBridgeProxy:          ch.L1StandardBridgeProxy,
 			proxyAdmin:                     ch.OpChainProxyAdminImpl,
 			permissionlessDelayedWETHProxy: ch.DelayedWethPermissionlessGameProxy,
+			sp1Verifier:                    ch.SP1Verifier,
 			sp1MockVerifier:                ch.SP1MockVerifier,
 			opSuccinctL2OutputOracle:       ch.OPSuccinctL2OutputOracle,
 		}

--- a/op-devstack/sysgo/deployer_succinct.go
+++ b/op-devstack/sysgo/deployer_succinct.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -247,12 +248,15 @@ func (o *Orchestrator) deployOpSuccinctL2OutputOracle(
 
 	WithValidityConfigDirsOption(o, l1CfgDir, l2CfgDir)
 
+	verifierAddr, err := l2Net.deployment.resolveSP1VerifierAddr()
+	require.NoError(err, "failed to get verifier address")
+
 	envVars := map[string]string{
 		"L1_RPC":           l1EL.UserRPC(),
 		"L1_BEACON_RPC":    l1CL.beaconHTTPAddr,
 		"L2_RPC":           strings.ReplaceAll(l2EL.UserRPC(), "ws://", "http://"),
 		"L2_NODE_RPC":      strings.ReplaceAll(l2CL.UserRPC(), "ws://", "http://"),
-		"VERIFIER_ADDRESS": l2Net.deployment.sp1MockVerifier.Hex(),
+		"VERIFIER_ADDRESS": verifierAddr.Hex(),
 		"PRIVATE_KEY":      l1PAOKeyStr,
 		"PROPOSER":         proposerAddr.Hex(),
 		"L1_CONFIG_DIR":    l1CfgDir,
@@ -424,7 +428,7 @@ func WithDeployOPSuccinctFaultDisputeGamePostDeploy(o *Orchestrator,
 
 	l2Net, ok := o.l2Nets.Get(l2CLID.ChainID())
 	o.P().Require().True(ok, "l2 network required")
-	l2Net.deployment.sp1MockVerifier = addrs.Sp1Verifier
+	l2Net.deployment.sp1Verifier = addrs.Sp1Verifier
 	l2Net.deployment.disputeGameFactoryProxy = addrs.FactoryProxy
 }
 
@@ -490,6 +494,9 @@ func (o *Orchestrator) deployOpSuccinctFaultDisputeGame(
 
 	WithFPConfigDirsOption(o, l1CfgDir, l2CfgDir)
 
+	verifierAddr, err := l2Net.deployment.resolveSP1VerifierAddr()
+	require.NoError(err, "failed to get verifier address")
+
 	envVars := map[string]string{
 		"L1_RPC":                              l1EL.UserRPC(),
 		"L1_BEACON_RPC":                       l1CL.beaconHTTPAddr,
@@ -499,14 +506,14 @@ func (o *Orchestrator) deployOpSuccinctFaultDisputeGame(
 		"DISPUTE_GAME_FINALITY_DELAY_SECONDS": fmt.Sprintf("%d", disputeGameFinalityDelaySecs),
 		"MAX_CHALLENGE_DURATION":              fmt.Sprintf("%d", maxChallengeDuration),
 		"MAX_PROVE_DURATION":                  fmt.Sprintf("%d", maxProveDuration),
-		"VERIFIER_ADDRESS":                    l2Net.deployment.sp1MockVerifier.Hex(),
+		"VERIFIER_ADDRESS":                    verifierAddr.Hex(),
 		"PRIVATE_KEY":                         l1PAOKeyStr,
 		"STARTING_L2_BLOCK_NUMBER":            fmt.Sprintf("%d", startingL2BlockNumber),
 		"L1_CONFIG_DIR":                       l1CfgDir,
 		"L2_CONFIG_DIR":                       l2CfgDir,
 		"OP_SUCCINCT_FAULT_DISPUTE_GAME_CONFIG_PATH": fdgConfigPath,
 		"PERMISSIONLESS_MODE":                        "true",
-		"OP_SUCCINCT_MOCK":                           "true",
+		"OP_SUCCINCT_MOCK":                           strconv.FormatBool(os.Getenv("NETWORK_PRIVATE_KEY") == ""),
 		"RUST_LOG":                                   "info",
 	}
 
@@ -603,7 +610,6 @@ func WithFdgMaxChallengeDuration(n uint64) FdgOption {
 func WithFdgMaxProveDuration(n uint64) FdgOption {
 	return func(cfg *FdgConfigs) {
 		cfg.maxProveDuration = &n
-
 	}
 }
 

--- a/op-devstack/sysgo/l2_metrics_dashboard.go
+++ b/op-devstack/sysgo/l2_metrics_dashboard.go
@@ -260,18 +260,15 @@ func getPrometheusConfigFilePath(p devtest.P, metricsEndpoints *locks.RWMap[stri
 
 // getGrafanaProvisioningDirPath returns the path to the grafana provisioning dir for metrics.
 // If the provisioning dir env var is set, this function will use that path. If not, a temp dir
-// will be created and removed when this process terminates.
-// Note: from the returned directory, the generated prometheus.yml will be at:
-//
-//	returned_dir_path/provisioning/datasources/prometheus.yml
+// will be created. The returned path is mounted to /etc/grafana/provisioning in Grafana.
 func getGrafanaProvisioningDirPath(p devtest.P) string {
 	// If the caller provides a Grafana provisioning directory, use that, otherwise use a temp dir
 	baseDir := os.Getenv(grafanaProvisioningDirEnvVar)
 	if baseDir == "" {
-		baseDir = filepath.Join(p.TempDir(), "grafana")
+		baseDir = filepath.Join(p.TempDir(), "grafana-provisioning")
 	}
 
-	dirPath := filepath.Join(baseDir, "provisioning/datasources")
+	dirPath := filepath.Join(baseDir, "datasources")
 	err := os.MkdirAll(dirPath, 0777)
 	p.Require().NoError(err, "getGrafanaProvisioningDirPath: error writing dir path", "dirPath", dirPath)
 

--- a/op-devstack/sysgo/l2_metrics_dashboard.go
+++ b/op-devstack/sysgo/l2_metrics_dashboard.go
@@ -90,16 +90,14 @@ func (g *L2MetricsDashboard) Stop() {
 func (g *L2MetricsDashboard) startPrometheus() {
 	// Create the sub-process.
 	// We pipe sub-process logs to the test-logger.
-	logOut := logpipe.ToLogger(g.p.Logger().New("component", "prometheus", "src", "stdout"))
-	logErr := logpipe.ToLogger(g.p.Logger().New("component", "prometheus", "src", "stderr"))
+	logOut := g.p.Logger().New("component", "prometheus", "src", "stdout")
+	logErr := g.p.Logger().New("component", "prometheus", "src", "stderr")
 
 	stdOutLogs := logpipe.LogProcessor(func(line []byte) {
-		e := logpipe.ParseRustStructuredLogs(line)
-		logOut(e)
+		logOut.Info(string(line))
 	})
 	stdErrLogs := logpipe.LogProcessor(func(line []byte) {
-		e := logpipe.ParseRustStructuredLogs(line)
-		logErr(e)
+		logErr.Warn(string(line))
 	})
 
 	g.prometheusSubprocess = NewSubProcess(g.p, stdOutLogs, stdErrLogs)
@@ -113,16 +111,14 @@ func (g *L2MetricsDashboard) startPrometheus() {
 func (g *L2MetricsDashboard) startGrafana() {
 	// Create the sub-process.
 	// We pipe sub-process logs to the test-logger.
-	logOut := logpipe.ToLogger(g.p.Logger().New("component", "grafana", "src", "stdout"))
-	logErr := logpipe.ToLogger(g.p.Logger().New("component", "grafana", "src", "stderr"))
+	logOut := g.p.Logger().New("component", "grafana", "src", "stdout")
+	logErr := g.p.Logger().New("component", "grafana", "src", "stderr")
 
 	stdOutLogs := logpipe.LogProcessor(func(line []byte) {
-		e := logpipe.ParseRustStructuredLogs(line)
-		logOut(e)
+		logOut.Info(string(line))
 	})
 	stdErrLogs := logpipe.LogProcessor(func(line []byte) {
-		e := logpipe.ParseRustStructuredLogs(line)
-		logErr(e)
+		logErr.Warn(string(line))
 	})
 
 	g.grafanaSubprocess = NewSubProcess(g.p, stdOutLogs, stdErrLogs)
@@ -268,11 +264,15 @@ func getGrafanaProvisioningDirPath(p devtest.P) string {
 		baseDir = filepath.Join(p.TempDir(), "grafana-provisioning")
 	}
 
-	dirPath := filepath.Join(baseDir, "datasources")
-	err := os.MkdirAll(dirPath, 0777)
-	p.Require().NoError(err, "getGrafanaProvisioningDirPath: error writing dir path", "dirPath", dirPath)
+	// Create all provisioning subdirectories that Grafana expects
+	for _, subdir := range []string{"datasources", "plugins", "alerting"} {
+		dirPath := filepath.Join(baseDir, subdir)
+		err := os.MkdirAll(dirPath, 0777)
+		p.Require().NoError(err, "getGrafanaProvisioningDirPath: error creating dir", "dirPath", dirPath)
+	}
 
-	p.Logger().Info("Created grafana/provisioning/datasources dir", "dirPath", dirPath)
+	dirPath := filepath.Join(baseDir, "datasources")
+	p.Logger().Info("Created grafana provisioning directories", "baseDir", baseDir)
 
 	filePath := filepath.Join(dirPath, "prometheus.yml")
 	file, err := os.Create(filePath)

--- a/op-devstack/sysgo/l2_proposer_faultproof.go
+++ b/op-devstack/sysgo/l2_proposer_faultproof.go
@@ -217,6 +217,7 @@ func WithSuccinctFaultProofProposerPostDeploy(orch *Orchestrator, proposerID sta
 	setEnvIfNotNil(envVars, "FAST_FINALITY_PROVING_LIMIT", cfg.fastFinalityProvingLimit)
 	setEnvIfNotNil(envVars, "RANGE_SPLIT_COUNT", cfg.rangeSplitCount)
 	setEnvIfNotNil(envVars, "MAX_CONCURRENT_RANGE_PROOFS", cfg.maxConcurrentRangeProofs)
+	setEnvIfNotNil(envVars, "TIMEOUT", cfg.timeout)
 	setEnvIfNotNil(envVars, "MOCK_MODE", cfg.mockMode)
 	setEnvIfNotNil(envVars, "RUST_LOG", cfg.rustLog)
 
@@ -273,6 +274,7 @@ type FaultProofProposerConfig struct {
 	rangeSplitCount          *uint64
 	maxConcurrentRangeProofs *uint64
 	fetchInterval            *uint64
+	timeout                  *uint64
 	mockMode                 *bool
 	rustLog                  *string
 	envFilePath              *string
@@ -329,6 +331,13 @@ func WithFPRangeSplitCount(n uint64) FaultProofProposerOption {
 func WithFPMaxConcurrentRangeProofs(n uint64) FaultProofProposerOption {
 	return FaultProofProposerOption(func(p devtest.P, id stack.L2ProposerID, cfg *FaultProofProposerConfig) {
 		cfg.maxConcurrentRangeProofs = &n
+	},
+	)
+}
+
+func WithFPTimeout(n uint64) FaultProofProposerOption {
+	return FaultProofProposerOption(func(p devtest.P, id stack.L2ProposerID, cfg *FaultProofProposerConfig) {
+		cfg.timeout = &n
 	},
 	)
 }

--- a/op-devstack/sysgo/l2_proposer_faultproof.go
+++ b/op-devstack/sysgo/l2_proposer_faultproof.go
@@ -227,6 +227,12 @@ func WithSuccinctFaultProofProposerPostDeploy(orch *Orchestrator, proposerID sta
 	err = writeEnvFile(envFile, envVars)
 	p.Require().NoError(err, "must write fault proof proposer env file")
 
+	if cfg.envFilePath != nil {
+		err = writeEnvFile(*cfg.envFilePath, envVars)
+		p.Require().NoError(err, "must write env file")
+		logger.Info("env file written", "path", *cfg.envFilePath)
+	}
+
 	execPath := os.Getenv("FAULT_PROOF_PROPOSER_EXEC_PATH")
 	p.Require().NotEmpty(execPath, "FAULT_PROOF_PROPOSER_EXEC_PATH environment variable must be set")
 	_, err = os.Stat(execPath)
@@ -262,6 +268,7 @@ type FaultProofProposerConfig struct {
 	fetchInterval            *uint64
 	mockMode                 *bool
 	rustLog                  *string
+	envFilePath              *string
 }
 
 type FaultProofProposerOption = ProposerOption[FaultProofProposerConfig]
@@ -329,6 +336,15 @@ func WithFPMockMode(enabled bool) FaultProofProposerOption {
 func WithFPRustLog(level string) FaultProofProposerOption {
 	return FaultProofProposerOption(func(p devtest.P, id stack.L2ProposerID, cfg *FaultProofProposerConfig) {
 		cfg.rustLog = &level
+	},
+	)
+}
+
+// WithFPWriteEnvFile enables writing environment variables to a file.
+// When set, the proposer will write all env vars to the specified path at startup.
+func WithFPWriteEnvFile(path string) FaultProofProposerOption {
+	return FaultProofProposerOption(func(p devtest.P, id stack.L2ProposerID, cfg *FaultProofProposerConfig) {
+		cfg.envFilePath = &path
 	},
 	)
 }

--- a/op-devstack/sysgo/l2_proposer_faultproof.go
+++ b/op-devstack/sysgo/l2_proposer_faultproof.go
@@ -217,9 +217,11 @@ func WithSuccinctFaultProofProposerPostDeploy(orch *Orchestrator, proposerID sta
 
 	if areMetricsEnabled() {
 		metricsPort, err := getAvailableLocalPort()
-		p.Require().NoError(err, "must get available port for metrics")
-		setEnvFromEnvOrDefault(envVars, "FAULT_PROOF_PROPOSER_METRICS_PORT", metricsPort)
-		envVars["FAULT_PROOF_PROPOSER_METRICS_ENABLED"] = "true"
+		require.NoError(err, "failed to get available port for metrics")
+		envVars["PROPOSER_METRICS_PORT"] = metricsPort
+		metricsTarget := NewPrometheusMetricsTarget("localhost", metricsPort, false)
+		orch.RegisterL2MetricsTargets(proposerID, metricsTarget)
+		logger.Info("Registered fault-proof proposer metrics", "port", metricsPort)
 	}
 
 	envDir := p.TempDir()

--- a/op-devstack/sysgo/l2_proposer_faultproof.go
+++ b/op-devstack/sysgo/l2_proposer_faultproof.go
@@ -178,22 +178,24 @@ func WithSuccinctFaultProofProposerPostDeploy(orch *Orchestrator, proposerID sta
 	l1BeaconRPC := l1CL.beaconHTTPAddr
 	l2RPC := strings.ReplaceAll(l2EL.UserRPC(), "ws://", "http://")
 	l2NodeRPC := strings.ReplaceAll(l2CL.UserRPC(), "ws://", "http://")
-	mockVerifierAddr := l2Net.deployment.sp1MockVerifier
 	disputeGameFactoryProxy := l2Net.deployment.disputeGameFactoryProxy
+
+	verifierAddr, err := l2Net.deployment.resolveSP1VerifierAddr()
+	require.NoError(err, "failed to get verifier address")
 
 	logger.Info("L1_RPC", "url", l1RPC)
 	logger.Info("L1_BEACON_RPC", "url", l1BeaconRPC)
 	logger.Info("L2_RPC", "url", l2RPC)
 	logger.Info("L2_NODE_RPC", "url", l2NodeRPC)
-	logger.Info("SP1MockVerifier", "address", mockVerifierAddr)
-	logger.Info("DisputeGameFactory", "address", disputeGameFactoryProxy)
+	logger.Info("VERIFIER_ADDRESS", "address", verifierAddr)
+	logger.Info("FACTORY_ADDRESS", "address", disputeGameFactoryProxy)
 
 	envVars := map[string]string{
 		"L1_RPC":           l1RPC,
 		"L1_BEACON_RPC":    l1BeaconRPC,
 		"L2_RPC":           l2RPC,
 		"L2_NODE_RPC":      l2NodeRPC,
-		"VERIFIER_ADDRESS": mockVerifierAddr.String(),
+		"VERIFIER_ADDRESS": verifierAddr.String(),
 		"FACTORY_ADDRESS":  disputeGameFactoryProxy.String(),
 		"GAME_TYPE":        "42",
 		"PRIVATE_KEY":      proposerKeyStr,

--- a/op-devstack/sysgo/l2_proposer_faultproof.go
+++ b/op-devstack/sysgo/l2_proposer_faultproof.go
@@ -196,7 +196,6 @@ func WithSuccinctFaultProofProposerPostDeploy(orch *Orchestrator, proposerID sta
 		"VERIFIER_ADDRESS": mockVerifierAddr.String(),
 		"FACTORY_ADDRESS":  disputeGameFactoryProxy.String(),
 		"GAME_TYPE":        "42",
-		"MOCK_MODE":        "true",
 		"PRIVATE_KEY":      proposerKeyStr,
 		"L1_CONFIG_DIR":    cfg.l1ConfigDir,
 		"L2_CONFIG_DIR":    cfg.l2ConfigDir,
@@ -204,6 +203,12 @@ func WithSuccinctFaultProofProposerPostDeploy(orch *Orchestrator, proposerID sta
 	}
 
 	setEnvFromEnvOrDefault(envVars, "NETWORK_PRIVATE_KEY", "")
+
+	if envVars["NETWORK_PRIVATE_KEY"] != "" {
+		envVars["MOCK_MODE"] = "false"
+	} else {
+		envVars["MOCK_MODE"] = "true"
+	}
 
 	// Optional parameters (override defaults if set)
 	setEnvIfNotNil(envVars, "PROPOSAL_INTERVAL_IN_BLOCKS", cfg.proposalIntervalInBlocks)

--- a/op-devstack/sysgo/l2_proposer_validity.go
+++ b/op-devstack/sysgo/l2_proposer_validity.go
@@ -297,22 +297,24 @@ func WithSuccinctValidityProposerPostDeploy(orch *Orchestrator, proposerID stack
 	l1BeaconRPC := l1CL.beaconHTTPAddr
 	l2RPC := strings.ReplaceAll(l2EL.UserRPC(), "ws://", "http://")
 	l2NodeRPC := strings.ReplaceAll(l2CL.UserRPC(), "ws://", "http://")
-	mockVerifierAddr := l2Net.deployment.sp1MockVerifier
 	l2ooAddr := l2Net.deployment.opSuccinctL2OutputOracle
+
+	verifierAddr, err := l2Net.deployment.resolveSP1VerifierAddr()
+	require.NoError(err, "failed to get verifier address")
 
 	logger.Info("L1_RPC", "url", l1RPC)
 	logger.Info("L1_BEACON_RPC", "url", l1BeaconRPC)
 	logger.Info("L2_RPC", "url", l2RPC)
 	logger.Info("L2_NODE_RPC", "url", l2NodeRPC)
-	logger.Info("OPSuccinctL2OutputOracle", "address", l2ooAddr)
-	logger.Info("SP1MockVerifier", "address", mockVerifierAddr)
+	logger.Info("VERIFIER_ADDRESS", "address", verifierAddr)
+	logger.Info("L2OO_ADDRESS", "address", l2ooAddr)
 
 	envVars := map[string]string{
 		"L1_RPC":           l1RPC,
 		"L1_BEACON_RPC":    l1BeaconRPC,
 		"L2_RPC":           l2RPC,
 		"L2_NODE_RPC":      l2NodeRPC,
-		"VERIFIER_ADDRESS": mockVerifierAddr.String(),
+		"VERIFIER_ADDRESS": verifierAddr.String(),
 		"L2OO_ADDRESS":     l2ooAddr.String(),
 		"DATABASE_URL":     embeddedPG.URL,
 		"PRIVATE_KEY":      proposerKeyStr,

--- a/op-devstack/sysgo/l2_proposer_validity.go
+++ b/op-devstack/sysgo/l2_proposer_validity.go
@@ -314,6 +314,15 @@ func WithSuccinctValidityProposerPostDeploy(orch *Orchestrator, proposerID stack
 		"LOG_FORMAT":       "json",
 	}
 
+	setEnvFromEnvOrDefault(envVars, "NETWORK_PRIVATE_KEY", "")
+
+	// Mock mode: default true, false if NETWORK_PRIVATE_KEY is set (real proving)
+	if envVars["NETWORK_PRIVATE_KEY"] != "" {
+		envVars["OP_SUCCINCT_MOCK"] = "false"
+	} else {
+		envVars["OP_SUCCINCT_MOCK"] = "true"
+	}
+
 	// Optional parameters (override defaults if set)
 	setEnvIfNotNil(envVars, "SUBMISSION_INTERVAL", cfg.submissionInterval)
 	setEnvIfNotNil(envVars, "RANGE_PROOF_INTERVAL", cfg.rangeProofInterval)
@@ -324,8 +333,6 @@ func WithSuccinctValidityProposerPostDeploy(orch *Orchestrator, proposerID stack
 	setEnvIfNotNil(envVars, "OP_SUCCINCT_CONFIG_NAME", cfg.opSuccinctConfigName)
 	setEnvIfNotNil(envVars, "OP_SUCCINCT_MOCK", cfg.mockMode)
 	setEnvIfNotNil(envVars, "RUST_LOG", cfg.rustLog)
-
-	setEnvFromEnvOrDefault(envVars, "NETWORK_PRIVATE_KEY", "")
 
 	if areMetricsEnabled() {
 		metricsPort, err := getAvailableLocalPort()

--- a/op-devstack/sysgo/l2_proposer_validity.go
+++ b/op-devstack/sysgo/l2_proposer_validity.go
@@ -82,6 +82,7 @@ type ValidityProposerConfig struct {
 	maxConcurrentProofRequests *uint64
 	maxConcurrentWitnessGen    *uint64
 	loopInterval               *uint64
+	provingTimeout             *uint64
 	opSuccinctConfigName       *string
 	mockMode                   *bool
 	rustLog                    *string
@@ -135,6 +136,12 @@ func WithVPMaxConcurrentWitnessGen(n uint64) ValidityProposerOption {
 func WithVPLoopInterval(n uint64) ValidityProposerOption {
 	return ValidityProposerOption(func(p devtest.P, id stack.L2ProposerID, cfg *ValidityProposerConfig) {
 		cfg.loopInterval = &n
+	})
+}
+
+func WithVPProvingTimeout(n uint64) ValidityProposerOption {
+	return ValidityProposerOption(func(p devtest.P, id stack.L2ProposerID, cfg *ValidityProposerConfig) {
+		cfg.provingTimeout = &n
 	})
 }
 
@@ -330,6 +337,7 @@ func WithSuccinctValidityProposerPostDeploy(orch *Orchestrator, proposerID stack
 	setEnvIfNotNil(envVars, "MAX_CONCURRENT_PROOF_REQUESTS", cfg.maxConcurrentProofRequests)
 	setEnvIfNotNil(envVars, "MAX_CONCURRENT_WITNESS_GEN", cfg.maxConcurrentWitnessGen)
 	setEnvIfNotNil(envVars, "LOOP_INTERVAL", cfg.loopInterval)
+	setEnvIfNotNil(envVars, "PROVING_TIMEOUT", cfg.provingTimeout)
 	setEnvIfNotNil(envVars, "OP_SUCCINCT_CONFIG_NAME", cfg.opSuccinctConfigName)
 	setEnvIfNotNil(envVars, "OP_SUCCINCT_MOCK", cfg.mockMode)
 	setEnvIfNotNil(envVars, "RUST_LOG", cfg.rustLog)

--- a/op-devstack/sysgo/l2_proposer_validity.go
+++ b/op-devstack/sysgo/l2_proposer_validity.go
@@ -85,6 +85,7 @@ type ValidityProposerConfig struct {
 	opSuccinctConfigName       *string
 	mockMode                   *bool
 	rustLog                    *string
+	envFilePath                *string
 }
 
 type ValidityProposerOption = ProposerOption[ValidityProposerConfig]
@@ -152,6 +153,14 @@ func WithVPMockMode(enabled bool) ValidityProposerOption {
 func WithVPRustLog(level string) ValidityProposerOption {
 	return ValidityProposerOption(func(p devtest.P, id stack.L2ProposerID, cfg *ValidityProposerConfig) {
 		cfg.rustLog = &level
+	})
+}
+
+// WithVPWriteEnvFile enables writing environment variables to a file.
+// When set, the proposer will write all env vars to the specified path at startup.
+func WithVPWriteEnvFile(path string) ValidityProposerOption {
+	return ValidityProposerOption(func(p devtest.P, id stack.L2ProposerID, cfg *ValidityProposerConfig) {
+		cfg.envFilePath = &path
 	})
 }
 
@@ -329,6 +338,12 @@ func WithSuccinctValidityProposerPostDeploy(orch *Orchestrator, proposerID stack
 	envFile := filepath.Join(envDir, fmt.Sprintf("validity-proposer-%s.env", proposerID.String()))
 	err = writeEnvFile(envFile, envVars)
 	p.Require().NoError(err, "must write validity proposer env file")
+
+	if cfg.envFilePath != nil {
+		err = writeEnvFile(*cfg.envFilePath, envVars)
+		p.Require().NoError(err, "must write env file")
+		logger.Info("env file written", "path", *cfg.envFilePath)
+	}
 
 	execPath := os.Getenv("VALIDITY_PROPOSER_EXEC_PATH")
 	p.Require().NotEmpty(execPath, "VALIDITY_PROPOSER_EXEC_PATH environment variable must be set")

--- a/op-devstack/sysgo/l2_proposer_validity.go
+++ b/op-devstack/sysgo/l2_proposer_validity.go
@@ -329,9 +329,11 @@ func WithSuccinctValidityProposerPostDeploy(orch *Orchestrator, proposerID stack
 
 	if areMetricsEnabled() {
 		metricsPort, err := getAvailableLocalPort()
-		p.Require().NoError(err, "must get available port for metrics")
-		setEnvFromEnvOrDefault(envVars, "VALIDITY_PROPOSER_METRICS_PORT", metricsPort)
-		envVars["VALIDITY_PROPOSER_METRICS_ENABLED"] = "true"
+		require.NoError(err, "failed to get available port for metrics")
+		envVars["METRICS_PORT"] = metricsPort
+		metricsTarget := NewPrometheusMetricsTarget("localhost", metricsPort, false)
+		orch.RegisterL2MetricsTargets(proposerID, metricsTarget)
+		logger.Info("Registered validity proposer metrics", "port", metricsPort)
 	}
 
 	envDir := p.TempDir()


### PR DESCRIPTION
## Summary

- Adds pipeline stage to deploy real SP1 verifier contracts at genesis deployment
- Introduces global deploy override `AggProofMode` (`plonk` default, `groth16` supported)
- sysgo uses `NETWORK_PRIVATE_KEY` to:
    - Select VERIFIER_ADDRESS = real SP1Verifier (else mock),
    - Disable mock mode (OP_SUCCINCT_MOCK / MOCK_MODE) automatically for proposers and deployment
- Adds metrics dashboard
     - Fix log piping and Grafana provisioning directory layout
     - Register proposer metrics targets when metrics are enabled
- Adds more configurable variables, importantly proving timeouts