### PR TITLE
feat(sysgo): add WithFPProveOnlyMode option for hardfork transitions

### DIFF
--- a/op-devstack/sysgo/deployer_succinct.go
+++ b/op-devstack/sysgo/deployer_succinct.go
@@ -538,6 +538,16 @@ func (o *Orchestrator) deployOpSuccinctFaultDisputeGame(
 		"RUST_LOG":                                   "info",
 	}
 
+	// Add vkey overrides if specified (for testing hardfork/version mismatch scenarios).
+	if cfgs.overrideAggregationVkey != nil {
+		envVars["OVERRIDE_AGGREGATION_VKEY"] = *cfgs.overrideAggregationVkey
+		logger.Info("Using override aggregation vkey", "vkey", *cfgs.overrideAggregationVkey)
+	}
+	if cfgs.overrideRangeVkeyCommitment != nil {
+		envVars["OVERRIDE_RANGE_VKEY_COMMITMENT"] = *cfgs.overrideRangeVkeyCommitment
+		logger.Info("Using override range vkey commitment", "commitment", *cfgs.overrideRangeVkeyCommitment)
+	}
+
 	envDir := p.TempDir()
 	envFile := filepath.Join(envDir, fmt.Sprintf("op-succinct-fdg-%s.env", strings.ReplaceAll(l2ChainID.String(), "-", "_")))
 	if err = WriteEnvFile(envFile, envVars); err != nil {
@@ -602,6 +612,10 @@ type FdgConfigs struct {
 	disputeGameFinalityDelaySecs *uint64
 	maxChallengeDuration         *uint64
 	maxProveDuration             *uint64
+	// Vkey overrides for testing hardfork/version mismatch scenarios.
+	// When set, these are passed to the deployment script instead of computing from ELFs.
+	overrideAggregationVkey      *string
+	overrideRangeVkeyCommitment  *string
 }
 
 type FdgOption func(*FdgConfigs)
@@ -631,6 +645,22 @@ func WithFdgMaxChallengeDuration(n uint64) FdgOption {
 func WithFdgMaxProveDuration(n uint64) FdgOption {
 	return func(cfg *FdgConfigs) {
 		cfg.maxProveDuration = &n
+	}
+}
+
+// WithFdgOverrideAggregationVkey overrides the aggregation vkey used during contract deployment.
+// This is useful for testing vkey mismatch scenarios (e.g., simulating old games with old vkeys).
+func WithFdgOverrideAggregationVkey(vkey string) FdgOption {
+	return func(cfg *FdgConfigs) {
+		cfg.overrideAggregationVkey = &vkey
+	}
+}
+
+// WithFdgOverrideRangeVkeyCommitment overrides the range vkey commitment used during contract deployment.
+// This is useful for testing vkey mismatch scenarios (e.g., simulating old games with old vkeys).
+func WithFdgOverrideRangeVkeyCommitment(commitment string) FdgOption {
+	return func(cfg *FdgConfigs) {
+		cfg.overrideRangeVkeyCommitment = &commitment
 	}
 }
 

--- a/op-devstack/sysgo/l2_proposer_faultproof.go
+++ b/op-devstack/sysgo/l2_proposer_faultproof.go
@@ -224,6 +224,7 @@ func WithSuccinctFaultProofProposerPostDeploy(orch *Orchestrator, proposerID sta
 	setEnvIfNotNil(envVars, "MAX_CONCURRENT_RANGE_PROOFS", cfg.maxConcurrentRangeProofs)
 	setEnvIfNotNil(envVars, "TIMEOUT", cfg.timeout)
 	setEnvIfNotNil(envVars, "MOCK_MODE", cfg.mockMode)
+	setEnvIfNotNil(envVars, "PROVE_ONLY_MODE", cfg.proveOnlyMode)
 	setEnvIfNotNil(envVars, "RUST_LOG", cfg.rustLog)
 
 	if areMetricsEnabled() {
@@ -281,6 +282,7 @@ type FaultProofProposerConfig struct {
 	fetchInterval            *uint64
 	timeout                  *uint64
 	mockMode                 *bool
+	proveOnlyMode            *bool
 	rustLog                  *string
 	envFilePath              *string
 }
@@ -350,6 +352,17 @@ func WithFPTimeout(n uint64) FaultProofProposerOption {
 func WithFPMockMode(enabled bool) FaultProofProposerOption {
 	return FaultProofProposerOption(func(p devtest.P, id stack.L2ProposerID, cfg *FaultProofProposerConfig) {
 		cfg.mockMode = &enabled
+	},
+	)
+}
+
+// WithFPProveOnlyMode enables prove-only mode for the proposer.
+// In prove-only mode, the proposer will only defend existing games but will not
+// create new games, resolve games, or claim bonds. This is used during hardfork
+// transitions when running an old proposer alongside a new one.
+func WithFPProveOnlyMode(enabled bool) FaultProofProposerOption {
+	return FaultProofProposerOption(func(p devtest.P, id stack.L2ProposerID, cfg *FaultProofProposerConfig) {
+		cfg.proveOnlyMode = &enabled
 	},
 	)
 }


### PR DESCRIPTION
Add prove-only mode configuration for the fault proof proposer. In prove-only mode, the proposer will only defend existing games but will not create new games, resolve games, or claim bonds.

This is used during hardfork transitions when running an old proposer alongside a new one to ensure existing games can still be defended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)