### PR TITLE
fix(sysgo): support float64 in setEnvIfNotNil

### DIFF
--- a/op-devstack/sysgo/util.go
+++ b/op-devstack/sysgo/util.go
@@ -49,6 +49,8 @@ func setEnvIfNotNil[T any](envVars map[string]string, key string, val *T) {
 		envVars[key] = v
 	case bool:
 		envVars[key] = fmt.Sprintf("%t", v)
+	case float64:
+		envVars[key] = fmt.Sprintf("%v", v)
 	default:
 		envVars[key] = fmt.Sprintf("%d", v)
 	}


### PR DESCRIPTION
## Summary
- Fix `setEnvIfNotNil` to correctly format `float64` values for environment variables

## Problem
The `setEnvIfNotNil` function was using `%d` format specifier for all non-string, non-bool types, which caused incorrect formatting for `float64` values:

```go
default:
    envVars[key] = fmt.Sprintf("%d", v)  // BUG: %d cannot format float64!
```

When setting `MALICIOUS_CHALLENGE_PERCENTAGE=100.0`, this produced garbage (e.g., `"4636737291354636288"`) instead of `"100.0"`, causing the Rust challenger binary to fail with:
```
Error: invalid float literal
```

## Fix
Add explicit case for `float64` using `%v` format specifier:

```go
case float64:
    envVars[key] = fmt.Sprintf("%v", v)
```

## Test plan
This fix is required for the defense e2e test in op-succinct PR #764.

🤖 Generated with [Claude Code](https://claude.com/claude-code)