### PR TITLE
feat(op-devstack): add withdrawal test support with OptimismPortalProxyAddr and setRespectedGameType

### DIFF
--- a/op-devstack/stack/l2_network.go
+++ b/op-devstack/stack/l2_network.go
@@ -64,6 +64,7 @@ type L2Deployment interface {
 	SystemConfigProxyAddr() common.Address
 	DisputeGameFactoryProxyAddr() common.Address
 	L1StandardBridgeProxyAddr() common.Address
+	OptimismPortalProxyAddr() common.Address
 	SP1VerifierAddr() common.Address
 	SP1MockVerifierAddr() common.Address
 	OPSuccinctL2OutputOracleAddr() common.Address

--- a/op-devstack/sysext/addrbook.go
+++ b/op-devstack/sysext/addrbook.go
@@ -12,9 +12,10 @@ const (
 	ProtocolVersionsAddressName = "ProtocolVersionsProxy"
 	SuperchainConfigAddressName = "SuperchainConfigProxy"
 
-	SystemConfigAddressName   = "systemConfigProxy"
-	DisputeGameFactoryName    = "disputeGameFactoryProxy"
-	L1StandardBridgeProxyName = "l1StandardBridgeProxy"
+	SystemConfigAddressName    = "systemConfigProxy"
+	DisputeGameFactoryName     = "disputeGameFactoryProxy"
+	L1StandardBridgeProxyName  = "l1StandardBridgeProxy"
+	OptimismPortalProxyName    = "optimismPortalProxy"
 
 	SP1Verifier              = "sp1Verifier"
 	sp1MockVerifier          = "sp1MockVerifier"
@@ -45,6 +46,7 @@ type l2AddressBook struct {
 	systemConfig             common.Address
 	disputeGameFactory       common.Address
 	l1StandardBridge         common.Address
+	optimismPortal           common.Address
 	sp1Verifier              common.Address
 	sp1MockVerifier          common.Address
 	opSuccinctL2OutputOracle common.Address
@@ -55,6 +57,7 @@ func newL2AddressBook(l1Addresses descriptors.AddressMap) *l2AddressBook {
 		systemConfig:             l1Addresses[SystemConfigAddressName],
 		disputeGameFactory:       l1Addresses[DisputeGameFactoryName],
 		l1StandardBridge:         l1Addresses[L1StandardBridgeProxyName],
+		optimismPortal:           l1Addresses[OptimismPortalProxyName],
 		sp1Verifier:              l1Addresses[SP1Verifier],
 		sp1MockVerifier:          l1Addresses[sp1MockVerifier],
 		opSuccinctL2OutputOracle: l1Addresses[OPSuccinctL2OutputOracle],
@@ -71,6 +74,10 @@ func (a *l2AddressBook) DisputeGameFactoryProxyAddr() common.Address {
 
 func (a *l2AddressBook) L1StandardBridgeProxyAddr() common.Address {
 	return a.l1StandardBridge
+}
+
+func (a *l2AddressBook) OptimismPortalProxyAddr() common.Address {
+	return a.optimismPortal
 }
 
 func (a *l2AddressBook) SP1VerifierAddr() common.Address {

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -183,6 +183,7 @@ type L2Deployment struct {
 	anchorStateRegistry            common.Address
 	disputeGameFactoryProxy        common.Address
 	l1StandardBridgeProxy          common.Address
+	optimismPortalProxy            common.Address
 	proxyAdmin                     common.Address
 	permissionlessDelayedWETHProxy common.Address
 	sp1Verifier                    common.Address
@@ -202,6 +203,10 @@ func (d *L2Deployment) DisputeGameFactoryProxyAddr() common.Address {
 
 func (d *L2Deployment) L1StandardBridgeProxyAddr() common.Address {
 	return d.l1StandardBridgeProxy
+}
+
+func (d *L2Deployment) OptimismPortalProxyAddr() common.Address {
+	return d.optimismPortalProxy
 }
 
 func (d *L2Deployment) ProxyAdminAddr() common.Address {
@@ -482,6 +487,7 @@ func (wb *worldBuilder) buildL2DeploymentOutputs() {
 			systemConfigProxyAddr:          ch.SystemConfigProxy,
 			disputeGameFactoryProxy:        ch.DisputeGameFactoryProxy,
 			l1StandardBridgeProxy:          ch.L1StandardBridgeProxy,
+			optimismPortalProxy:            ch.OptimismPortalProxy,
 			proxyAdmin:                     ch.OpChainProxyAdminImpl,
 			permissionlessDelayedWETHProxy: ch.DelayedWethPermissionlessGameProxy,
 			sp1Verifier:                    ch.SP1Verifier,

--- a/op-devstack/sysgo/deployer_succinct.go
+++ b/op-devstack/sysgo/deployer_succinct.go
@@ -18,13 +18,63 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	bindingspreview "github.com/ethereum-optimism/optimism/op-node/bindings/preview"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
 )
+
+// OPSuccinctGameType is the game type used by OPSuccinct fault dispute games.
+// This must match the GAME_TYPE value used in the deployment scripts.
+const OPSuccinctGameType uint32 = 42
+
+// setRespectedGameType updates the respectedGameType on OptimismPortal2 to the specified game type.
+// This is necessary for withdrawals to work correctly with the StandardBridge DSL,
+// which filters games by the portal's respectedGameType.
+func setRespectedGameType(o *Orchestrator, l1ELID stack.L1ELNodeID, portalAddr common.Address, gameType uint32) {
+	p := o.P()
+	require := p.Require()
+	logger := p.Logger().New("component", "succinct-deployer")
+
+	l1ChainID := l1ELID.ChainID()
+
+	l1EL, ok := o.l1ELs.Get(l1ELID)
+	require.True(ok, "l1 EL node required")
+
+	rpcClient, err := rpc.DialContext(p.Ctx(), l1EL.UserRPC())
+	require.NoError(err, "failed to dial L1 RPC")
+	client := ethclient.NewClient(rpcClient)
+
+	// Get the guardian key (same as L1ProxyAdminOwner in devstack)
+	chainOps := devkeys.ChainOperatorKeys(l1ChainID.ToBig())
+	guardianKey, err := o.keys.Secret(chainOps(devkeys.L1ProxyAdminOwnerRole))
+	require.NoError(err, "failed to get guardian key")
+
+	transactOpts, err := bind.NewKeyedTransactorWithChainID(guardianKey, l1ChainID.ToBig())
+	require.NoError(err, "failed to create transact opts")
+	transactOpts.Context = p.Ctx()
+
+	portal, err := bindingspreview.NewOptimismPortal2(portalAddr, client)
+	require.NoError(err, "failed to create OptimismPortal2 binding")
+
+	logger.Info("Setting respectedGameType on OptimismPortal2",
+		"portal", portalAddr.Hex(),
+		"gameType", gameType)
+
+	tx, err := portal.SetRespectedGameType(transactOpts, gameType)
+	require.NoError(err, "failed to send setRespectedGameType tx")
+
+	_, err = wait.ForReceiptOK(p.Ctx(), client, tx.Hash())
+	require.NoError(err, "failed to wait for setRespectedGameType receipt")
+
+	logger.Info("Successfully set respectedGameType", "txHash", tx.Hash().Hex())
+}
 
 // =============================================================
 // SP1MockVerifier Deployment
@@ -451,6 +501,10 @@ func WithDeployOPSuccinctFaultDisputeGamePostDeploy(o *Orchestrator,
 	l2Net.deployment.sp1Verifier = addrs.Sp1Verifier
 	l2Net.deployment.anchorStateRegistry = addrs.AnchorStateRegistry
 	l2Net.deployment.disputeGameFactoryProxy = addrs.FactoryProxy
+
+	// Set respectedGameType to 42 (OPSuccinct game type) on OptimismPortal2
+	// This is required for the StandardBridge DSL to find games of the correct type
+	setRespectedGameType(o, l1ELID, l2Net.deployment.optimismPortalProxy, OPSuccinctGameType)
 }
 
 // deployOpSuccinctFaultDisputeGame deploys an OPSuccinctFaultDisputeGame contract

--- a/op-devstack/sysgo/deployer_succinct.go
+++ b/op-devstack/sysgo/deployer_succinct.go
@@ -19,11 +19,10 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
-	bindingspreview "github.com/ethereum-optimism/optimism/op-node/bindings/preview"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
@@ -34,10 +33,12 @@ import (
 // This must match the GAME_TYPE value used in the deployment scripts.
 const OPSuccinctGameType uint32 = 42
 
-// setRespectedGameType updates the respectedGameType on OptimismPortal2 to the specified game type.
+// setRespectedGameType updates the respectedGameType on AnchorStateRegistry to the specified game type.
 // This is necessary for withdrawals to work correctly with the StandardBridge DSL,
 // which filters games by the portal's respectedGameType.
-func setRespectedGameType(o *Orchestrator, l1ELID stack.L1ELNodeID, portalAddr common.Address, gameType uint32) {
+// Note: In recent Optimism contract versions, setRespectedGameType is on AnchorStateRegistry,
+// not OptimismPortal2. The guardian (SuperchainConfigGuardian) is required to call this function.
+func setRespectedGameType(o *Orchestrator, l1ELID stack.L1ELNodeID, anchorStateRegistryAddr common.Address, gameType uint32) {
 	p := o.P()
 	require := p.Require()
 	logger := p.Logger().New("component", "succinct-deployer")
@@ -51,29 +52,41 @@ func setRespectedGameType(o *Orchestrator, l1ELID stack.L1ELNodeID, portalAddr c
 	require.NoError(err, "failed to dial L1 RPC")
 	client := ethclient.NewClient(rpcClient)
 
-	// Get the guardian key (same as L1ProxyAdminOwner in devstack)
-	chainOps := devkeys.ChainOperatorKeys(l1ChainID.ToBig())
-	guardianKey, err := o.keys.Secret(chainOps(devkeys.L1ProxyAdminOwnerRole))
+	// Get the guardian key (SuperchainConfigGuardian - required to call setRespectedGameType)
+	superOps := devkeys.SuperchainOperatorKeys(l1ChainID.ToBig())
+	guardianKey, err := o.keys.Secret(superOps(devkeys.SuperchainConfigGuardianKey))
 	require.NoError(err, "failed to get guardian key")
 
-	transactOpts, err := bind.NewKeyedTransactorWithChainID(guardianKey, l1ChainID.ToBig())
-	require.NoError(err, "failed to create transact opts")
-	transactOpts.Context = p.Ctx()
-
-	portal, err := bindingspreview.NewOptimismPortal2(portalAddr, client)
-	require.NoError(err, "failed to create OptimismPortal2 binding")
-
-	logger.Info("Setting respectedGameType on OptimismPortal2",
-		"portal", portalAddr.Hex(),
+	logger.Info("Setting respectedGameType on AnchorStateRegistry",
+		"anchorStateRegistry", anchorStateRegistryAddr.Hex(),
 		"gameType", gameType)
 
-	tx, err := portal.SetRespectedGameType(transactOpts, gameType)
+	// AnchorStateRegistry.setRespectedGameType(uint32)
+	// Selector: bytes4(keccak256("setRespectedGameType(uint32)")) = 0x7fc48504
+	// We use a raw call since there's no AnchorStateRegistry binding available
+	selector := crypto.Keccak256([]byte("setRespectedGameType(uint32)"))[:4]
+	// Encode gameType as uint32 (padded to 32 bytes)
+	gameTypeBytes := common.LeftPadBytes(big.NewInt(int64(gameType)).Bytes(), 32)
+	data := append(selector, gameTypeBytes...)
+
+	// Send raw transaction to AnchorStateRegistry
+	nonce, err := client.PendingNonceAt(p.Ctx(), crypto.PubkeyToAddress(guardianKey.PublicKey))
+	require.NoError(err, "failed to get nonce")
+
+	gasPrice, err := client.SuggestGasPrice(p.Ctx())
+	require.NoError(err, "failed to get gas price")
+
+	tx := types.NewTransaction(nonce, anchorStateRegistryAddr, big.NewInt(0), 100000, gasPrice, data)
+	signedTx, err := types.SignTx(tx, types.NewEIP155Signer(l1ChainID.ToBig()), guardianKey)
+	require.NoError(err, "failed to sign tx")
+
+	err = client.SendTransaction(p.Ctx(), signedTx)
 	require.NoError(err, "failed to send setRespectedGameType tx")
 
-	_, err = wait.ForReceiptOK(p.Ctx(), client, tx.Hash())
+	_, err = wait.ForReceiptOK(p.Ctx(), client, signedTx.Hash())
 	require.NoError(err, "failed to wait for setRespectedGameType receipt")
 
-	logger.Info("Successfully set respectedGameType", "txHash", tx.Hash().Hex())
+	logger.Info("Successfully set respectedGameType", "txHash", signedTx.Hash().Hex())
 }
 
 // =============================================================
@@ -502,9 +515,9 @@ func WithDeployOPSuccinctFaultDisputeGamePostDeploy(o *Orchestrator,
 	l2Net.deployment.anchorStateRegistry = addrs.AnchorStateRegistry
 	l2Net.deployment.disputeGameFactoryProxy = addrs.FactoryProxy
 
-	// Set respectedGameType to 42 (OPSuccinct game type) on OptimismPortal2
+	// Set respectedGameType to 42 (OPSuccinct game type) on AnchorStateRegistry
 	// This is required for the StandardBridge DSL to find games of the correct type
-	setRespectedGameType(o, l1ELID, l2Net.deployment.optimismPortalProxy, OPSuccinctGameType)
+	setRespectedGameType(o, l1ELID, addrs.AnchorStateRegistry, OPSuccinctGameType)
 }
 
 // deployOpSuccinctFaultDisputeGame deploys an OPSuccinctFaultDisputeGame contract

--- a/op-devstack/sysgo/deployer_succinct.go
+++ b/op-devstack/sysgo/deployer_succinct.go
@@ -107,65 +107,6 @@ func setStandardPortalRespectedGameType(o *Orchestrator, l1ELID stack.L1ELNodeID
 	logger.Info("Successfully set respectedGameType on standard AnchorStateRegistry", "txHash", signedTx.Hash().Hex())
 }
 
-// setRespectedGameType updates the respectedGameType on AnchorStateRegistry to the specified game type.
-// This is necessary for withdrawals to work correctly with the StandardBridge DSL,
-// which filters games by the portal's respectedGameType.
-// Note: In recent Optimism contract versions, setRespectedGameType is on AnchorStateRegistry,
-// not OptimismPortal2. The OPSuccinct FDG deployment creates a MockSystemConfig with the deployer
-// (L1ProxyAdminOwnerRole) as the guardian, so we must use that key to call setRespectedGameType.
-func setRespectedGameType(o *Orchestrator, l1ELID stack.L1ELNodeID, anchorStateRegistryAddr common.Address, gameType uint32) {
-	p := o.P()
-	require := p.Require()
-	logger := p.Logger().New("component", "succinct-deployer")
-
-	l1ChainID := l1ELID.ChainID()
-
-	l1EL, ok := o.l1ELs.Get(l1ELID)
-	require.True(ok, "l1 EL node required")
-
-	rpcClient, err := rpc.DialContext(p.Ctx(), l1EL.UserRPC())
-	require.NoError(err, "failed to dial L1 RPC")
-	client := ethclient.NewClient(rpcClient)
-
-	// Get the guardian key - the OPSuccinct FDG deployment creates a MockSystemConfig with
-	// the deployer (L1ProxyAdminOwnerRole) as the guardian. This is different from the standard
-	// devstack which uses SuperchainConfigGuardianKey.
-	chainOps := devkeys.ChainOperatorKeys(l1ChainID.ToBig())
-	guardianKey, err := o.keys.Secret(chainOps(devkeys.L1ProxyAdminOwnerRole))
-	require.NoError(err, "failed to get guardian key (L1ProxyAdminOwner)")
-
-	logger.Info("Setting respectedGameType on AnchorStateRegistry",
-		"anchorStateRegistry", anchorStateRegistryAddr.Hex(),
-		"gameType", gameType)
-
-	// AnchorStateRegistry.setRespectedGameType(uint32)
-	// Selector: bytes4(keccak256("setRespectedGameType(uint32)")) = 0x7fc48504
-	// We use a raw call since there's no AnchorStateRegistry binding available
-	selector := crypto.Keccak256([]byte("setRespectedGameType(uint32)"))[:4]
-	// Encode gameType as uint32 (padded to 32 bytes)
-	gameTypeBytes := common.LeftPadBytes(big.NewInt(int64(gameType)).Bytes(), 32)
-	data := append(selector, gameTypeBytes...)
-
-	// Send raw transaction to AnchorStateRegistry
-	nonce, err := client.PendingNonceAt(p.Ctx(), crypto.PubkeyToAddress(guardianKey.PublicKey))
-	require.NoError(err, "failed to get nonce")
-
-	gasPrice, err := client.SuggestGasPrice(p.Ctx())
-	require.NoError(err, "failed to get gas price")
-
-	tx := types.NewTransaction(nonce, anchorStateRegistryAddr, big.NewInt(0), 100000, gasPrice, data)
-	signedTx, err := types.SignTx(tx, types.NewEIP155Signer(l1ChainID.ToBig()), guardianKey)
-	require.NoError(err, "failed to sign tx")
-
-	err = client.SendTransaction(p.Ctx(), signedTx)
-	require.NoError(err, "failed to send setRespectedGameType tx")
-
-	_, err = wait.ForReceiptOK(p.Ctx(), client, signedTx.Hash())
-	require.NoError(err, "failed to wait for setRespectedGameType receipt")
-
-	logger.Info("Successfully set respectedGameType", "txHash", signedTx.Hash().Hex())
-}
-
 // =============================================================
 // SP1MockVerifier Deployment
 // =============================================================

--- a/op-devstack/sysgo/deployer_succinct.go
+++ b/op-devstack/sysgo/deployer_succinct.go
@@ -595,10 +595,9 @@ func WithDeployOPSuccinctFaultDisputeGamePostDeploy(o *Orchestrator,
 	// not a separate OPSuccinct DGF. This ensures withdrawals work correctly because
 	// OptimismPortal2 looks up games from the same DGF where they were created.
 
-	// Set respectedGameType to 42 (OPSuccinct game type) on BOTH AnchorStateRegistries:
-	// 1. The OPSuccinct-deployed AnchorStateRegistry (for the OPSuccinct DGF)
-	// 2. The standard devstack's AnchorStateRegistry (for the StandardBridge DSL which uses the standard portal)
-	setRespectedGameType(o, l1ELID, addrs.AnchorStateRegistry, OPSuccinctGameType)
+	// Set respectedGameType to 42 (OPSuccinct game type) on the standard AnchorStateRegistry.
+	// Since we're using the standard ASR for games (to pass isGameProper() checks),
+	// we only need to set it once using the SuperchainConfigGuardianKey.
 	setStandardPortalRespectedGameType(o, l1ELID, l2CLID.ChainID(), OPSuccinctGameType)
 }
 
@@ -673,6 +672,25 @@ func (o *Orchestrator) deployOpSuccinctFaultDisputeGame(
 	logger.Info("Using existing standard DisputeGameFactory for OPSuccinct games",
 		"standardDgf", standardDgf.Hex())
 
+	// Get the standard AnchorStateRegistry address by reading from OptimismPortal2.
+	// This ensures games reference the same ASR that OptimismPortal2 uses for isGameProper() checks.
+	portalAddr := l2Net.rollupCfg.DepositContractAddress
+	rpcClient, err := rpc.DialContext(p.Ctx(), l1EL.UserRPC())
+	require.NoError(err, "failed to dial L1 RPC for ASR lookup")
+	client := ethclient.NewClient(rpcClient)
+
+	asrSelector := crypto.Keccak256([]byte("anchorStateRegistry()"))[:4]
+	asrResult, err := client.CallContract(p.Ctx(), ethereum.CallMsg{
+		To:   &portalAddr,
+		Data: asrSelector,
+	}, nil)
+	require.NoError(err, "failed to read anchorStateRegistry from portal")
+	require.Len(asrResult, 32, "unexpected anchorStateRegistry result length")
+
+	standardAsr := common.BytesToAddress(asrResult[12:32])
+	logger.Info("Using existing standard AnchorStateRegistry for OPSuccinct games",
+		"standardAsr", standardAsr.Hex())
+
 	envVars := map[string]string{
 		"L1_RPC":                              l1EL.UserRPC(),
 		"L1_BEACON_RPC":                       l1CL.beaconHTTPAddr,
@@ -691,6 +709,9 @@ func (o *Orchestrator) deployOpSuccinctFaultDisputeGame(
 		"PERMISSIONLESS_MODE":                        "true",
 		"OP_SUCCINCT_MOCK":                           strconv.FormatBool(os.Getenv("NETWORK_PRIVATE_KEY") == ""),
 		"RUST_LOG":                                   "info",
+		// Pass the standard ASR address so games reference the same ASR as OptimismPortal2.
+		// This is required for isGameProper() check in proveWithdrawal to pass.
+		"EXISTING_ANCHOR_STATE_REGISTRY": standardAsr.Hex(),
 		// Pass the standard DGF address so the deployment registers game type 42 there
 		// instead of creating a new DGF. This ensures OptimismPortal2 uses the same DGF.
 		"EXISTING_DISPUTE_GAME_FACTORY_PROXY": standardDgf.Hex(),

--- a/op-devstack/sysgo/deployer_succinct.go
+++ b/op-devstack/sysgo/deployer_succinct.go
@@ -37,7 +37,8 @@ const OPSuccinctGameType uint32 = 42
 // This is necessary for withdrawals to work correctly with the StandardBridge DSL,
 // which filters games by the portal's respectedGameType.
 // Note: In recent Optimism contract versions, setRespectedGameType is on AnchorStateRegistry,
-// not OptimismPortal2. The guardian (SuperchainConfigGuardian) is required to call this function.
+// not OptimismPortal2. The OPSuccinct FDG deployment creates a MockSystemConfig with the deployer
+// (L1ProxyAdminOwnerRole) as the guardian, so we must use that key to call setRespectedGameType.
 func setRespectedGameType(o *Orchestrator, l1ELID stack.L1ELNodeID, anchorStateRegistryAddr common.Address, gameType uint32) {
 	p := o.P()
 	require := p.Require()
@@ -52,10 +53,12 @@ func setRespectedGameType(o *Orchestrator, l1ELID stack.L1ELNodeID, anchorStateR
 	require.NoError(err, "failed to dial L1 RPC")
 	client := ethclient.NewClient(rpcClient)
 
-	// Get the guardian key (SuperchainConfigGuardian - required to call setRespectedGameType)
-	superOps := devkeys.SuperchainOperatorKeys(l1ChainID.ToBig())
-	guardianKey, err := o.keys.Secret(superOps(devkeys.SuperchainConfigGuardianKey))
-	require.NoError(err, "failed to get guardian key")
+	// Get the guardian key - the OPSuccinct FDG deployment creates a MockSystemConfig with
+	// the deployer (L1ProxyAdminOwnerRole) as the guardian. This is different from the standard
+	// devstack which uses SuperchainConfigGuardianKey.
+	chainOps := devkeys.ChainOperatorKeys(l1ChainID.ToBig())
+	guardianKey, err := o.keys.Secret(chainOps(devkeys.L1ProxyAdminOwnerRole))
+	require.NoError(err, "failed to get guardian key (L1ProxyAdminOwner)")
 
 	logger.Info("Setting respectedGameType on AnchorStateRegistry",
 		"anchorStateRegistry", anchorStateRegistryAddr.Hex(),

--- a/op-devstack/sysgo/deployer_succinct.go
+++ b/op-devstack/sysgo/deployer_succinct.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -32,6 +33,79 @@ import (
 // OPSuccinctGameType is the game type used by OPSuccinct fault dispute games.
 // This must match the GAME_TYPE value used in the deployment scripts.
 const OPSuccinctGameType uint32 = 42
+
+// setStandardPortalRespectedGameType reads the AnchorStateRegistry from the standard OptimismPortal2
+// and sets its respectedGameType to the specified game type. This is necessary because the
+// StandardBridge DSL uses the portal from the rollup config (standard devstack deployment),
+// which has its own AnchorStateRegistry separate from the OPSuccinct-deployed one.
+func setStandardPortalRespectedGameType(o *Orchestrator, l1ELID stack.L1ELNodeID, l2ChainID eth.ChainID, gameType uint32) {
+	p := o.P()
+	require := p.Require()
+	logger := p.Logger().New("component", "succinct-deployer")
+
+	l1ChainID := l1ELID.ChainID()
+
+	l1EL, ok := o.l1ELs.Get(l1ELID)
+	require.True(ok, "l1 EL node required")
+
+	rpcClient, err := rpc.DialContext(p.Ctx(), l1EL.UserRPC())
+	require.NoError(err, "failed to dial L1 RPC")
+	client := ethclient.NewClient(rpcClient)
+
+	// Get the standard portal address from the L2 network's rollup config
+	l2Net, ok := o.l2Nets.Get(l2ChainID)
+	require.True(ok, "l2 network required")
+	portalAddr := l2Net.rollupCfg.DepositContractAddress
+
+	logger.Info("Reading AnchorStateRegistry from standard OptimismPortal2",
+		"portal", portalAddr.Hex())
+
+	// Read anchorStateRegistry() from the portal
+	// Function selector: bytes4(keccak256("anchorStateRegistry()")) = 0x72d5fe21
+	asrSelector := crypto.Keccak256([]byte("anchorStateRegistry()"))[:4]
+	asrResult, err := client.CallContract(p.Ctx(), ethereum.CallMsg{
+		To:   &portalAddr,
+		Data: asrSelector,
+	}, nil)
+	require.NoError(err, "failed to read anchorStateRegistry from portal")
+	require.Len(asrResult, 32, "unexpected anchorStateRegistry result length")
+
+	anchorStateRegistryAddr := common.BytesToAddress(asrResult[12:32])
+	logger.Info("Found standard AnchorStateRegistry",
+		"anchorStateRegistry", anchorStateRegistryAddr.Hex())
+
+	// Get the guardian key (SuperchainConfigGuardian - required for standard ASR)
+	superOps := devkeys.SuperchainOperatorKeys(l1ChainID.ToBig())
+	guardianKey, err := o.keys.Secret(superOps(devkeys.SuperchainConfigGuardianKey))
+	require.NoError(err, "failed to get guardian key (SuperchainConfigGuardian)")
+
+	logger.Info("Setting respectedGameType on standard AnchorStateRegistry",
+		"anchorStateRegistry", anchorStateRegistryAddr.Hex(),
+		"gameType", gameType)
+
+	// AnchorStateRegistry.setRespectedGameType(uint32)
+	selector := crypto.Keccak256([]byte("setRespectedGameType(uint32)"))[:4]
+	gameTypeBytes := common.LeftPadBytes(big.NewInt(int64(gameType)).Bytes(), 32)
+	data := append(selector, gameTypeBytes...)
+
+	nonce, err := client.PendingNonceAt(p.Ctx(), crypto.PubkeyToAddress(guardianKey.PublicKey))
+	require.NoError(err, "failed to get nonce")
+
+	gasPrice, err := client.SuggestGasPrice(p.Ctx())
+	require.NoError(err, "failed to get gas price")
+
+	tx := types.NewTransaction(nonce, anchorStateRegistryAddr, big.NewInt(0), 100000, gasPrice, data)
+	signedTx, err := types.SignTx(tx, types.NewEIP155Signer(l1ChainID.ToBig()), guardianKey)
+	require.NoError(err, "failed to sign tx")
+
+	err = client.SendTransaction(p.Ctx(), signedTx)
+	require.NoError(err, "failed to send setRespectedGameType tx")
+
+	_, err = wait.ForReceiptOK(p.Ctx(), client, signedTx.Hash())
+	require.NoError(err, "failed to wait for setRespectedGameType receipt")
+
+	logger.Info("Successfully set respectedGameType on standard AnchorStateRegistry", "txHash", signedTx.Hash().Hex())
+}
 
 // setRespectedGameType updates the respectedGameType on AnchorStateRegistry to the specified game type.
 // This is necessary for withdrawals to work correctly with the StandardBridge DSL,
@@ -518,9 +592,11 @@ func WithDeployOPSuccinctFaultDisputeGamePostDeploy(o *Orchestrator,
 	l2Net.deployment.anchorStateRegistry = addrs.AnchorStateRegistry
 	l2Net.deployment.disputeGameFactoryProxy = addrs.FactoryProxy
 
-	// Set respectedGameType to 42 (OPSuccinct game type) on AnchorStateRegistry
-	// This is required for the StandardBridge DSL to find games of the correct type
+	// Set respectedGameType to 42 (OPSuccinct game type) on BOTH AnchorStateRegistries:
+	// 1. The OPSuccinct-deployed AnchorStateRegistry (for the OPSuccinct DGF)
+	// 2. The standard devstack's AnchorStateRegistry (for the StandardBridge DSL which uses the standard portal)
 	setRespectedGameType(o, l1ELID, addrs.AnchorStateRegistry, OPSuccinctGameType)
+	setStandardPortalRespectedGameType(o, l1ELID, l2CLID.ChainID(), OPSuccinctGameType)
 }
 
 // deployOpSuccinctFaultDisputeGame deploys an OPSuccinctFaultDisputeGame contract

--- a/op-devstack/sysgo/deployer_succinct.go
+++ b/op-devstack/sysgo/deployer_succinct.go
@@ -590,7 +590,10 @@ func WithDeployOPSuccinctFaultDisputeGamePostDeploy(o *Orchestrator,
 	o.P().Require().True(ok, "l2 network required")
 	l2Net.deployment.sp1Verifier = addrs.Sp1Verifier
 	l2Net.deployment.anchorStateRegistry = addrs.AnchorStateRegistry
-	l2Net.deployment.disputeGameFactoryProxy = addrs.FactoryProxy
+	// NOTE: We intentionally do NOT overwrite l2Net.deployment.disputeGameFactoryProxy.
+	// The OPSuccinct games are now registered in the STANDARD DGF (which OptimismPortal2 uses),
+	// not a separate OPSuccinct DGF. This ensures withdrawals work correctly because
+	// OptimismPortal2 looks up games from the same DGF where they were created.
 
 	// Set respectedGameType to 42 (OPSuccinct game type) on BOTH AnchorStateRegistries:
 	// 1. The OPSuccinct-deployed AnchorStateRegistry (for the OPSuccinct DGF)
@@ -664,6 +667,12 @@ func (o *Orchestrator) deployOpSuccinctFaultDisputeGame(
 	verifierAddr, err := l2Net.deployment.resolveSP1VerifierAddr()
 	require.NoError(err, "failed to get verifier address")
 
+	// Get the standard DGF address from the devstack deployment.
+	// This ensures games are created in the same DGF that OptimismPortal2 references.
+	standardDgf := o.wb.outL2Deployment[l2ChainID].DisputeGameFactoryProxyAddr()
+	logger.Info("Using existing standard DisputeGameFactory for OPSuccinct games",
+		"standardDgf", standardDgf.Hex())
+
 	envVars := map[string]string{
 		"L1_RPC":                              l1EL.UserRPC(),
 		"L1_BEACON_RPC":                       l1CL.beaconHTTPAddr,
@@ -682,6 +691,9 @@ func (o *Orchestrator) deployOpSuccinctFaultDisputeGame(
 		"PERMISSIONLESS_MODE":                        "true",
 		"OP_SUCCINCT_MOCK":                           strconv.FormatBool(os.Getenv("NETWORK_PRIVATE_KEY") == ""),
 		"RUST_LOG":                                   "info",
+		// Pass the standard DGF address so the deployment registers game type 42 there
+		// instead of creating a new DGF. This ensures OptimismPortal2 uses the same DGF.
+		"EXISTING_DISPUTE_GAME_FACTORY_PROXY": standardDgf.Hex(),
 	}
 
 	envDir := p.TempDir()


### PR DESCRIPTION
## Summary

Add infrastructure required for op-succinct withdrawal e2e tests to work with the standard OptimismPortal2 and AnchorStateRegistry.

## Changes

### 1. Expose OptimismPortalProxyAddr in L2Deployment interface
- Add `OptimismPortalProxyAddr()` method to `L2Deployment` interface in `stack/l2_network.go`
- Add implementation in `sysext/addrbook.go` and `sysgo/deployer.go`
- Required for tests to access OptimismPortal2 for withdrawal lifecycle testing

### 2. Add setStandardPortalRespectedGameType function
- Sets respectedGameType on the standard devstack's AnchorStateRegistry to 42 (OPSuccinct game type)
- Required because StandardBridge DSL reads respectedGameType from the standard portal's ASR, which must match the game type created by OPSuccinct

### 3. Support using existing DGF and ASR
- Pass `EXISTING_DISPUTE_GAME_FACTORY_PROXY` to register game type 42 in the standard DGF instead of creating a new one
- Pass `EXISTING_ANCHOR_STATE_REGISTRY` to use the standard ASR instead of deploying a new one
- Required for OptimismPortal2's `isGameProper()` check to pass (games must reference the same ASR/DGF that the portal uses)

## Why These Changes Are Needed

The withdrawal test flow requires:
1. **Same DGF**: OptimismPortal2 must use the same DisputeGameFactory where games are created
2. **Same ASR**: Games must reference the same AnchorStateRegistry that OptimismPortal2 uses for `isGameProper()` validation
3. **Correct respectedGameType**: StandardBridge DSL filters games by respectedGameType (must be 42, not default 1)

Without these changes, the withdrawal test fails with:
- "out-of-bounds access" (wrong DGF)
- "OptimismPortal_ImproperDisputeGame" (wrong ASR)
- "no game found" (wrong respectedGameType)

## Files Changed

| File | Change |
|------|--------|
| `stack/l2_network.go` | Add `OptimismPortalProxyAddr()` to interface |
| `sysext/addrbook.go` | Add constant and getter for portal address |
| `sysgo/deployer.go` | Add field and getter for portal address |
| `sysgo/deployer_succinct.go` | Add `setStandardPortalRespectedGameType`, pass existing DGF/ASR to deployment |

## Related

- op-succinct PR: https://github.com/succinctlabs/op-succinct/pull/781
- Issue: https://github.com/succinctlabs/op-succinct/issues/783