### PR TITLE
fix(sysgo): support SP1_PROVER=cluster in verifier and mock mode

### DIFF
--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -234,7 +234,7 @@ func (d *L2Deployment) OPSuccinctL2OutputOracleAddr() common.Address {
 // otherwise uses the mock verifier for local testing.
 func (d *L2Deployment) resolveSP1VerifierAddr() (common.Address, error) {
 	var addr common.Address
-	if os.Getenv("NETWORK_PRIVATE_KEY") != "" {
+	if os.Getenv("NETWORK_PRIVATE_KEY") != "" || os.Getenv("SP1_PROVER") == "cluster" {
 		addr = d.sp1Verifier
 	} else {
 		addr = d.sp1MockVerifier

--- a/op-devstack/sysgo/l2_proposer_validity.go
+++ b/op-devstack/sysgo/l2_proposer_validity.go
@@ -332,8 +332,8 @@ func WithSuccinctValidityProposerPostDeploy(orch *Orchestrator, proposerID stack
 
 	setEnvFromEnvOrDefault(envVars, "NETWORK_PRIVATE_KEY", "")
 
-	// Mock mode: default true, false if NETWORK_PRIVATE_KEY is set (real proving)
-	if envVars["NETWORK_PRIVATE_KEY"] != "" {
+	// Mock mode: default true, false if NETWORK_PRIVATE_KEY is set or SP1_PROVER=cluster (real proving)
+	if envVars["NETWORK_PRIVATE_KEY"] != "" || os.Getenv("SP1_PROVER") == "cluster" {
 		envVars["OP_SUCCINCT_MOCK"] = "false"
 	} else {
 		envVars["OP_SUCCINCT_MOCK"] = "true"


### PR DESCRIPTION
## Summary
- resolveSP1VerifierAddr() now uses the real SP1 Plonk verifier when SP1_PROVER=cluster
- Mock mode defaulting logic also checks for cluster mode to set OP_SUCCINCT_MOCK=false

## Context
When running E2E tests with self-hosted cluster proving (SP1_PROVER=cluster), the test harness deployed SP1MockVerifier and set OP_SUCCINCT_MOCK=true because it only checked NETWORK_PRIVATE_KEY to detect real proving mode. This caused:
1. assert(false) reverts when the proposer tried to submit real Plonk proofs to L2OO via the MockVerifier
2. mock and cluster modes are mutually exclusive panic in the validity binary

## Test plan
- [x] Validated with test-e2e-sysgo-altda using SP1_PROVER=cluster on self-hosted EKS cluster
- [x] Mock proving CI tests unaffected (no SP1_PROVER env var set)