### PR TITLE
fix(sysgo): deploy own ASR for OPSuccinct, share only standard DGF

### DIFF
--- a/op-devstack/sysgo/deployer_succinct.go
+++ b/op-devstack/sysgo/deployer_succinct.go
@@ -536,9 +536,15 @@ func WithDeployOPSuccinctFaultDisputeGamePostDeploy(o *Orchestrator,
 	// not a separate OPSuccinct DGF. This ensures withdrawals work correctly because
 	// OptimismPortal2 looks up games from the same DGF where they were created.
 
-	// Set respectedGameType to 42 (OPSuccinct game type) on the standard AnchorStateRegistry.
-	// Since we're using the standard ASR for games (to pass isGameProper() checks),
-	// we only need to set it once using the SuperchainConfigGuardianKey.
+	// Set respectedGameType to 42 (OPSuccinct game type) on the *standard* AnchorStateRegistry.
+	// OPSuccinct games use their own ASR (initialized with respectedGameType=42 by
+	// DeployOPSuccinctFDG), so this call is NOT for OPSuccinct's own validation path.
+	// It is required for OptimismPortal2's withdrawal flow: Portal2 reads from its own
+	// standard ASR, and that ASR's `isGameClaimValid` ultimately checks the game's
+	// `wasRespectedGameTypeWhenCreated()`. Bumping `respectedGameType=42` on the standard
+	// ASR also sets `respectedGameTypeUpdatedAt = block.timestamp`, ensuring OPSuccinct
+	// games created after this point are not treated as "retired" by the standard ASR
+	// during withdrawal validation. The Guardian key is required by the standard ASR.
 	setStandardPortalRespectedGameType(o, l1ELID, l2CLID.ChainID(), OPSuccinctGameType)
 }
 
@@ -608,29 +614,16 @@ func (o *Orchestrator) deployOpSuccinctFaultDisputeGame(
 	require.NoError(err, "failed to get verifier address")
 
 	// Get the standard DGF address from the devstack deployment.
-	// This ensures games are created in the same DGF that OptimismPortal2 references.
+	// This ensures games are created in the same DGF that OptimismPortal2 references —
+	// which is what OptimismPortal2's ASR needs for isGameProper() (via isGameRegistered)
+	// during withdrawal validation. OPSuccinct does NOT reuse the standard ASR itself:
+	// the standard ASR is initialized with a placeholder startingAnchorRoot that does not
+	// match the proposer's L2 view, which would break fast-finality bootstrap. Instead,
+	// OPSuccinct deploys its own ASR (initialized via DeployOPSuccinctFDG with a
+	// proposer-derived startingAnchorRoot) that references this same standard DGF.
 	standardDgf := o.wb.outL2Deployment[l2ChainID].DisputeGameFactoryProxyAddr()
 	logger.Info("Using existing standard DisputeGameFactory for OPSuccinct games",
 		"standardDgf", standardDgf.Hex())
-
-	// Get the standard AnchorStateRegistry address by reading from OptimismPortal2.
-	// This ensures games reference the same ASR that OptimismPortal2 uses for isGameProper() checks.
-	portalAddr := l2Net.rollupCfg.DepositContractAddress
-	rpcClient, err := rpc.DialContext(p.Ctx(), l1EL.UserRPC())
-	require.NoError(err, "failed to dial L1 RPC for ASR lookup")
-	client := ethclient.NewClient(rpcClient)
-
-	asrSelector := crypto.Keccak256([]byte("anchorStateRegistry()"))[:4]
-	asrResult, err := client.CallContract(p.Ctx(), ethereum.CallMsg{
-		To:   &portalAddr,
-		Data: asrSelector,
-	}, nil)
-	require.NoError(err, "failed to read anchorStateRegistry from portal")
-	require.Len(asrResult, 32, "unexpected anchorStateRegistry result length")
-
-	standardAsr := common.BytesToAddress(asrResult[12:32])
-	logger.Info("Using existing standard AnchorStateRegistry for OPSuccinct games",
-		"standardAsr", standardAsr.Hex())
 
 	envVars := map[string]string{
 		"L1_RPC":                              l1EL.UserRPC(),
@@ -650,11 +643,14 @@ func (o *Orchestrator) deployOpSuccinctFaultDisputeGame(
 		"PERMISSIONLESS_MODE":                        "true",
 		"OP_SUCCINCT_MOCK":                           strconv.FormatBool(os.Getenv("NETWORK_PRIVATE_KEY") == ""),
 		"RUST_LOG":                                   "info",
-		// Pass the standard ASR address so games reference the same ASR as OptimismPortal2.
-		// This is required for isGameProper() check in proveWithdrawal to pass.
-		"EXISTING_ANCHOR_STATE_REGISTRY": standardAsr.Hex(),
 		// Pass the standard DGF address so the deployment registers game type 42 there
-		// instead of creating a new DGF. This ensures OptimismPortal2 uses the same DGF.
+		// instead of creating a new DGF. This ensures OptimismPortal2's ASR (which uses
+		// the standard DGF for isGameRegistered checks) can validate OPSuccinct games
+		// during withdrawal proving. OPSuccinct deploys its own AnchorStateRegistry that
+		// also references this DGF but holds an independent (proposer-derived) starting
+		// anchor and respectedGameType; do NOT also pass EXISTING_ANCHOR_STATE_REGISTRY
+		// since the standard ASR's placeholder startingAnchorRoot would break OPSuccinct
+		// fast-finality bootstrap.
 		"EXISTING_DISPUTE_GAME_FACTORY_PROXY": standardDgf.Hex(),
 	}
 


### PR DESCRIPTION
## Summary
- Drop \`EXISTING_ANCHOR_STATE_REGISTRY\` env var (and the standard‑ASR lookup block) from sysgo's OPSuccinct deploy. OPSuccinct now deploys its own AnchorStateRegistry (initialized by \`DeployOPSuccinctFDG.s.sol\` with a proposer‑derived \`startingAnchorRoot\` and \`respectedGameType=42\`) while still passing \`EXISTING_DISPUTE_GAME_FACTORY_PROXY\` so games remain registered in the standard DGF that OptimismPortal2 references.
- Fixes the long‑running fast‑finality regression where \`TestFaultProofProposer_FastFinality_Progress\` failed with repeated \`InvalidProof()\` (0x09bde339) and anchor stuck at L2=0.

## Why
\`#337\` (this branch) made sysgo reuse the standard ASR for OPSuccinct games on the premise that \`OptimismPortal2.isGameProper()\` validation needs both Portal2 and OPSuccinct games to share an ASR. On closer inspection, \`isGameProper\` only checks DGF membership (via \`isGameRegistered\`), blacklist, and retirement — none of which require **ASR** sharing. Same‑DGF is sufficient.

Because the standard ASR is initialized by devstack with a placeholder \`startingAnchorRoot\` (\`l2BlockNumber=0\`, root that does not match the proposer's op‑geth view at block 0), OPSuccinct's first fast‑finality game inherited that placeholder as its \`startingOutputRoot\`. The proposer's aggregation proof commits the real op‑geth \`outputRoot(0)\`, and the on‑chain SP1 verifier reconstructs public values from the placeholder, so they disagree and every proof gets rejected with \`InvalidProof()\`. The anchor never advances; after ~32 min the test trips the 1800s anchor‑lag check.

## What changed
\`op-devstack/sysgo/deployer_succinct.go\`:
- Remove the standard‑ASR lookup (call to \`anchorStateRegistry()\` on the standard portal) — no longer needed
- Remove the \`EXISTING_ANCHOR_STATE_REGISTRY\` env entry from the OPSuccinct FDG deploy env file
- Keep \`EXISTING_DISPUTE_GAME_FACTORY_PROXY\` so games still register in the standard DGF
- Keep the \`setStandardPortalRespectedGameType(42)\` call — Portal2's ASR still needs to recognize game type 42
- Update surrounding comments to explain the asymmetry

Net: ‑24 / +14 in a single file.

The v3.7.0 \`AnchorStateRegistry\` tracks \`disputeGameBlacklist\`, \`respectedGameType\`, and \`retirementTimestamp\` in its own storage (no portal field), so OPSuccinct's own ASR is fully self‑sufficient for parent‑game validation under \`OPSuccinctFaultDisputeGame.initialize()\`; no cross‑ASR coordination is needed.

## Test plan
- [x] \`go build ./op-devstack/sysgo/\` clean
- [x] \`go vet ./op-devstack/sysgo/\` clean
- [x] gpu‑06 sysgo Network Prover \`TestFaultProofProposer_FastFinality_Progress\` → **PASS (4303.62s)**, 0 \`InvalidProof\`, anchor advanced 1 → 1681 in lock‑step with games (matches v4.3.1 PASS pattern within 1% timing)
- [x] Same run also covers \`TestFaultProofProposer_Progress\` (normal mode) — passes
- [x] Forge contract build reached test phase → green
- [ ] Withdrawal test path (\`#781\` still open in succinctlabs/op-succinct) — not exercised here; mechanism preserved per analysis (games still in standard DGF, Portal2's ASR still validates via DGF membership)

## Reproduction (before fix)
Sysgo Network Prover workflow on op-succinct \`#911\` (\`02f882f5\`) and \`#914\` (\`e4ca84c6\`) reliably fails \`TestFaultProofProposer_FastFinality_Progress\` after ~41 min:
\`\`\`
Task GameProving { game_address: 0x..., is_defense: false } failed: Failed to send transaction
Caused by: server returned an error response: error code 3: execution reverted, data: \"0x09bde339\"
...
anchor lag 1920 seconds exceeds max 1800 seconds
--- FAIL: TestFaultProofProposer_FastFinality_Progress (2475.69s)
\`\`\`
0x09bde339 = \`InvalidProof()\` from the SP1 verifier.

## Follow‑ups (not in this PR)
- op‑succinct submodule SHA bump (after merge here)
- (Process) op‑succinct CI workflow gate currently only re‑runs the network‑prover job when ELFs change; consider also triggering on \`tests/optimism\` submodule changes or \`contracts/script/fp/**\` so future sysgo‑only regressions surface immediately

## Related
- Companion of \`#337\` (this branch) — same author, refines the same withdrawal‑test infrastructure
- Surfaced first in op‑succinct \`#911\` (kona dep bump) which happened to bump ELFs and re‑trigger the workflow